### PR TITLE
ROI scaling bug fix and moving metadata

### DIFF
--- a/src/core/experiment_manager.py
+++ b/src/core/experiment_manager.py
@@ -28,7 +28,11 @@ class Experiment:
         "display": {"colormap": "gray", "brightness": 1.0},
         "processing": {"auto_save": True},
     })
-    roi: Optional[Dict[str, int]] = None  # {"x": int, "y": int, "width": int, "height": int}
+    # Store ROI coordinates in image pixel space (not widget/display space)
+    # Format: {"x": int, "y": int, "width": int, "height": int}
+    # These coordinates are in original image pixels, ensuring ROI stays fixed to
+    # the image region regardless of window size or scaling
+    roi: Optional[Dict[str, int]] = None
 
     def to_json(self) -> Dict[str, Any]:
         return {
@@ -50,6 +54,8 @@ class Experiment:
                 "processing": {"history": self.processing_history},
                 "analysis": {"results": self.analysis_results, "plots": []},
                 "settings": self.settings,
+                # Save ROI coordinates to .nexp file
+                # Coordinates are in image pixel space, not display/widget space
                 "roi": self.roi,
             },
         }
@@ -73,6 +79,10 @@ class Experiment:
             processing_history=exp.get("processing", {}).get("history", []),
             analysis_results=exp.get("analysis", {}).get("results", {}),
             settings=exp.get("settings", {}),
+
+            # Load ROI coordinates from .nexp file
+            # Coordinates are in image pixel space and will be converted to display
+            # coordinates when drawing (see image_viewer.py _show_current method)
             roi=exp.get("roi"),
         )
 


### PR DESCRIPTION
**Fixes the following:**
- Makes ROI coordinates stay within the relative coordinates of the image.
- Moves the metadata to below the slider, and makes it take up less space

**Adds the following:**
- Saves ROI to .nexp save file
- Upon loading of past experiment, runs ROI intensity function based on the saved ROI coordinates so the ROI graph automatically pops up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region of interest (ROI) functionality to experiments with persistent storage
  * ROI coordinates are automatically saved and restored when reopening experiment files
  * ROI display correctly maintains positioning during image viewer resizing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->