### PR TITLE
Implemented exception class to cancel image alignment without crash

### DIFF
--- a/src/ui/alignment_progress_dialog.py
+++ b/src/ui/alignment_progress_dialog.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QTextEdit,
 )
+from PySide6.QtGui import QCloseEvent
 
 
 class AlignmentProgressDialog(QDialog):
@@ -67,4 +68,11 @@ class AlignmentProgressDialog(QDialog):
         self.status_label.setText("Cancelling...")
         self.log_text.append("Cancellation requested by user.")
         super().reject()
+    
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """Handle window close event (X button)."""
+        self._cancelled = True
+        self.status_label.setText("Cancelling...")
+        self.log_text.append("Cancellation requested by user.")
+        super().closeEvent(event)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from core.experiment_manager import Experiment, ExperimentManager
 from core.data_analyzer import DataAnalyzer
-from core.image_processor import ImageProcessor
+from core.image_processor import ImageProcessor, AlignmentCancelledException
 from core.roi import ROI, ROIShape
 from utils.file_handler import ImageStackHandler
 from ui.image_viewer import ImageViewer
@@ -910,7 +910,7 @@ class MainWindow(QMainWindow):
                 )
             )
             
-            # Check if alignment was cancelled
+            # Check if alignment was cancelled (shouldn't reach here if cancelled, but double-check)
             if progress_dialog.is_cancelled():
                 progress_dialog.close()
                 QMessageBox.information(
@@ -979,6 +979,14 @@ class MainWindow(QMainWindow):
                 if load_reply == QMessageBox.Yes:
                     self.viewer.set_stack(output_dir)
             
+        except AlignmentCancelledException:
+            # Alignment was cancelled by user - this is expected, not an error
+            progress_dialog.close()
+            QMessageBox.information(
+                self,
+                "Alignment Cancelled",
+                "Image alignment was cancelled. No changes were saved."
+            )
         except Exception as e:
             progress_dialog.close()
             QMessageBox.critical(


### PR DESCRIPTION
Added exception class to handle image alignment cancelling. 
However, the program experiences a bottleneck while canceling image alignment and takes a while to do so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to cancel image alignment at any stage during processing
  * Dialog close button now properly cancels alignment with graceful cleanup

* **Improvements**
  * Enhanced progress feedback during alignment with cancellation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->