### PR TITLE
fix: update cd workflow configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,26 +17,27 @@ jobs:
           SHA="${{ github.sha }}"
           echo "Checking CI status for commit $SHA ..."
 
-          # Poll for up to 10 minutes (CI may still be running when the tag is pushed)
+          # Poll for up to 10 minutes (CI may still be running when the tag is pushed).
+          # Check only the CI workflow status; combined status stays 'pending' while CD runs.
           for i in $(seq 1 20); do
-            STATUS=$(gh api "repos/${{ github.repository }}/commits/$SHA/status" \
-              --jq '.state')
-            echo "Attempt $i: combined status = $STATUS"
+            BODY=$(gh api "repos/${{ github.repository }}/commits/$SHA/status")
+            CI_STATE=$(echo "$BODY" | jq -r '.statuses[] | select(.context == "CI") | .state')
+            COMBINED=$(echo "$BODY" | jq -r '.state')
+            echo "Attempt $i: combined = $COMBINED, CI = ${CI_STATE:-<none>}"
 
-            if [ "$STATUS" = "success" ]; then
-              echo "All CI checks passed."
+            if [ "$CI_STATE" = "success" ]; then
+              echo "CI checks passed."
               exit 0
-            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
+            elif [ "$CI_STATE" = "failure" ] || [ "$CI_STATE" = "error" ]; then
               echo "::error::CI checks failed or errored for $SHA. Aborting release."
               exit 1
             fi
 
-            # Still pending — wait 30s and retry
-            echo "Status is '$STATUS', waiting 30s ..."
+            echo "CI not done yet, waiting 30s ..."
             sleep 30
           done
 
-          echo "::error::CI checks did not complete within 10 minutes. Aborting release."
+          echo "::error::CI did not complete within 10 minutes. Aborting release."
           exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the CD workflow to improve how it checks CI status before proceeding with a release. The main change is to ensure that only the CI workflow status is considered, rather than the combined status, which can remain 'pending' while CD runs.

Improvements to CI status checking in CD workflow:

* Changed the polling logic in `.github/workflows/cd.yml` to check specifically for the CI workflow status by parsing the `statuses` array and filtering for the `"CI"` context, instead of relying on the combined commit status. This prevents false positives when the CD workflow itself keeps the combined status 'pending'.
* Updated log output and error messages to clarify the distinction between CI and combined statuses, making troubleshooting easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment pipeline status detection logic to more accurately identify CI job states and handle edge cases with refined timeout and status messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->