### PR TITLE
fix: update CD workflow configuration in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,28 +15,43 @@ jobs:
         run: |
           set -euo pipefail
           SHA="${{ github.sha }}"
-          echo "Checking CI status for commit $SHA ..."
-
-          # Poll for up to 10 minutes (CI may still be running when the tag is pushed).
-          # Check only the CI workflow status; combined status stays 'pending' while CD runs.
+          echo "Checking CI check runs for commit $SHA ..."
+          # GitHub Actions reports via Check Runs (job names), not commit status context.
+          # CI workflow jobs: lint, test, build, release-prep. Require all four success.
+          CI_JOBS="lint test build release-prep"
           for i in $(seq 1 20); do
-            BODY=$(gh api "repos/${{ github.repository }}/commits/$SHA/status")
-            CI_STATE=$(echo "$BODY" | jq -r '.statuses[] | select(.context == "CI") | .state')
-            COMBINED=$(echo "$BODY" | jq -r '.state')
-            echo "Attempt $i: combined = $COMBINED, CI = ${CI_STATE:-<none>}"
-
-            if [ "$CI_STATE" = "success" ]; then
-              echo "CI checks passed."
-              exit 0
-            elif [ "$CI_STATE" = "failure" ] || [ "$CI_STATE" = "error" ]; then
-              echo "::error::CI checks failed or errored for $SHA. Aborting release."
+            BODY=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" -q '.check_runs')
+            echo "Attempt $i:"
+            FAIL=0
+            DONE=0
+            for JOB in $CI_JOBS; do
+              RUN=$(echo "$BODY" | jq -r --arg j "$JOB" '.[] | select(.name == $j) | "\(.status) \(.conclusion // "null")"' | head -1)
+              if [ -z "$RUN" ]; then
+                echo "  $JOB: not found (CI may not have started)"
+                DONE=1
+                break
+              fi
+              STAT=$(echo "$RUN" | awk '{print $1}')
+              CONCL=$(echo "$RUN" | awk '{print $2}')
+              echo "  $JOB: status=$STAT conclusion=$CONCL"
+              if [ "$STAT" != "completed" ]; then
+                DONE=1
+              elif [ "$CONCL" != "success" ]; then
+                echo "::error::CI job $JOB concluded with $CONCL. Aborting release."
+                FAIL=1
+                break
+              fi
+            done
+            if [ "$FAIL" -eq 1 ]; then
               exit 1
             fi
-
+            if [ "$DONE" -eq 0 ]; then
+              echo "All CI check runs passed."
+              exit 0
+            fi
             echo "CI not done yet, waiting 30s ..."
             sleep 30
           done
-
           echo "::error::CI did not complete within 10 minutes. Aborting release."
           exit 1
         env:


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/cd.yml` to improve how CI job statuses are checked before proceeding with deployment. The main change is switching from checking the combined commit status to checking individual CI job check runs, ensuring that all required jobs have completed successfully.

CI job status checking improvements:

* Changed the script to poll individual CI job check runs (`lint`, `test`, `build`, `release-prep`) instead of the combined commit status, making the release process more robust and accurate.
* Added logic to ensure all required CI jobs are found and completed with a `success` conclusion before proceeding, aborting the release if any job fails or is missing.
* Improved logging and error handling for CI job status, providing clearer output and reasons for aborting the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration check verification process to improve deployment reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->