### PR TITLE
fix: update cd workflow configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,8 @@ jobs:
           SHA="${{ github.sha }}"
           echo "Checking CI check runs for commit $SHA ..."
           # GitHub Actions reports via Check Runs (job names), not commit status context.
-          # CI workflow jobs: lint, test, build, release-prep. Require all four success.
+          # CI workflow jobs: lint, test, build, release-prep. Require completed; accept success or skipped.
+          # (release-prep can show as skipped when multiple runs exist for the same commit, e.g. PR vs push.)
           CI_JOBS="lint test build release-prep"
           for i in $(seq 1 20); do
             BODY=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" -q '.check_runs')
@@ -36,7 +37,7 @@ jobs:
               echo "  $JOB: status=$STAT conclusion=$CONCL"
               if [ "$STAT" != "completed" ]; then
                 DONE=1
-              elif [ "$CONCL" != "success" ]; then
+              elif [ "$CONCL" = "failure" ] || [ "$CONCL" = "cancelled" ] || [ "$CONCL" = "timed_out" ] || [ "$CONCL" = "action_required" ]; then
                 echo "::error::CI job $JOB concluded with $CONCL. Aborting release."
                 FAIL=1
                 break


### PR DESCRIPTION
This pull request updates the CI/CD workflow to make the release process more robust by allowing certain jobs to be considered successful even if they are skipped, as long as they are not failed or cancelled. This change is particularly relevant for the `release-prep` job, which can be skipped in some scenarios (such as when multiple runs exist for the same commit).

CI/CD workflow improvements:

* Updated the job status check logic in `.github/workflows/cd.yml` to treat jobs as passing if they are either successful or skipped, rather than requiring all to be strictly successful. This prevents unnecessary release failures when jobs like `release-prep` are skipped due to multiple runs for the same commit.
* Modified the failure condition to only abort the release if a job concludes with `failure`, `cancelled`, `timed_out`, or `action_required`, rather than any non-success conclusion.