### PR TITLE
ci: add macOS code signing and notarization to macos-release-assets job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,54 @@ jobs:
           ./build-macos-app.sh
           ./build-macos-dmg.sh
 
+      - name: Import Developer ID certificate
+        env:
+          DEVELOPER_ID_CERT: ${{ secrets.DEVELOPER_ID_CERT }}
+          CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PASS=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASS" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASS" build.keychain
+          echo "$DEVELOPER_ID_CERT" | base64 --decode > /tmp/certificate.p12
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASS" build.keychain
+          security list-keychains -d user -s build.keychain \
+            $(security list-keychains -d user | sed 's/"//g')
+          rm /tmp/certificate.p12
+
+      - name: Sign macOS app
+        run: |
+          SIGN_IDENTITY=$(security find-identity -v -p codesigning build.keychain \
+            | grep "Developer ID Application" | head -1 | awk '{print $2}')
+          codesign --deep --force --options runtime \
+            --sign "$SIGN_IDENTITY" \
+            dist/Neurolight.app
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain build.keychain || true
+
+      - name: Re-package signed app into DMG
+        run: ./build-macos-dmg.sh
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+        run: |
+          xcrun notarytool submit dist/Neurolight.dmg \
+            --apple-id "$APPLE_ID" \
+            --team-id "$TEAM_ID" \
+            --password "$APP_SPECIFIC_PASSWORD" \
+            --wait
+
+      - name: Staple notarization
+        run: xcrun stapler staple dist/Neurolight.dmg
+
       - name: Upload DMG to GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:


### PR DESCRIPTION
Imports the Developer ID certificate into a temporary keychain, signs dist/Neurolight.app with codesign (--deep --force --options runtime), re-packages the DMG with the signed app, notarizes via xcrun notarytool, and staples the ticket so Gatekeeper accepts the DMG offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS release workflow to include code signing and Apple notarization, ensuring macOS builds are properly validated and trusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->