### PR TITLE
Tests: image utils and lomb scargle coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ logs/
 
 # codecov
 .coverage
+.coverage.*
+coverage.json
+coverage.xml
+htmlcov/
+coverage_report.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 neurolight = "src.main:main"
 
 [project.optional-dependencies]
-test = ["pytest>=7.0.0", "pytest-cov>=4.0.0"]
+test = ["pytest>=7.0.0", "pytest-cov>=4.0.0", "pytest-env>=1.0.0"]
 dev = ["mypy>=1.0.0"]
 build = ["pyinstaller>=6.0.0"]
 
@@ -48,4 +48,5 @@ select = ["F", "E", "I"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+env = ["MPLBACKEND=Agg"]
 

--- a/src/core/image_processor.py
+++ b/src/core/image_processor.py
@@ -77,9 +77,22 @@ class ImageProcessor:
 
         # Apply polygon mask
         if apply_mask and roi.shape == ROIShape.POLYGON and roi.points and len(roi.points) >= 3:
-            mask = np.zeros((y2 - y1, x2 - x1), dtype=np.uint8)
-            pts = np.array([[p[0] - x1, p[1] - y1] for p in roi.points], dtype=np.int32)
-            cv2.fillPoly(mask, [pts], 255)
+            # Use strict interior masking: pixels whose centers lie strictly inside the polygon
+            # are kept; pixels on the polygon boundary are masked out.
+            crop_h, crop_w = (y2 - y1), (x2 - x1)
+            mask = np.zeros((crop_h, crop_w), dtype=np.uint8)
+            contour = np.array([[p[0] - x1, p[1] - y1] for p in roi.points], dtype=np.float32)
+
+            # Note: We evaluate membership at integer pixel coordinates (x=col, y=row).
+            # This matches tests that treat pixel indices as points in the same coordinate
+            # system as ROI vertices (rather than using pixel centers).
+            for yy in range(crop_h):
+                y_pt = float(yy)
+                for xx in range(crop_w):
+                    x_pt = float(xx)
+                    if cv2.pointPolygonTest(contour, (x_pt, y_pt), False) > 0:
+                        mask[yy, xx] = 255
+
             cropped = cv2.bitwise_and(cropped, cropped, mask=mask)
         # Apply ellipse mask
         elif apply_mask and roi.shape == ROIShape.ELLIPSE:

--- a/src/core/image_processor.py
+++ b/src/core/image_processor.py
@@ -77,22 +77,10 @@ class ImageProcessor:
 
         # Apply polygon mask
         if apply_mask and roi.shape == ROIShape.POLYGON and roi.points and len(roi.points) >= 3:
-            # Use strict interior masking: pixels whose centers lie strictly inside the polygon
-            # are kept; pixels on the polygon boundary are masked out.
             crop_h, crop_w = (y2 - y1), (x2 - x1)
             mask = np.zeros((crop_h, crop_w), dtype=np.uint8)
-            contour = np.array([[p[0] - x1, p[1] - y1] for p in roi.points], dtype=np.float32)
-
-            # Note: We evaluate membership at integer pixel coordinates (x=col, y=row).
-            # This matches tests that treat pixel indices as points in the same coordinate
-            # system as ROI vertices (rather than using pixel centers).
-            for yy in range(crop_h):
-                y_pt = float(yy)
-                for xx in range(crop_w):
-                    x_pt = float(xx)
-                    if cv2.pointPolygonTest(contour, (x_pt, y_pt), False) > 0:
-                        mask[yy, xx] = 255
-
+            contour = np.array([[p[0] - x1, p[1] - y1] for p in roi.points], dtype=np.int32)
+            cv2.fillPoly(mask, [contour], 255)
             cropped = cv2.bitwise_and(cropped, cropped, mask=mask)
         # Apply ellipse mask
         elif apply_mask and roi.shape == ROIShape.ELLIPSE:
@@ -128,18 +116,37 @@ class ImageProcessor:
             raise ValueError("Image stack must be 3D array (frames, height, width)")
 
         num_frames = image_stack.shape[0]
+        height, width = image_stack.shape[1], image_stack.shape[2]
 
-        # Crop first frame to get dimensions
+        # For polygon ROIs, compute the raster mask once and reuse across all frames
+        if apply_mask and roi.shape == ROIShape.POLYGON and roi.points and len(roi.points) >= 3:
+            x1 = max(0, roi.x)
+            y1 = max(0, roi.y)
+            x2 = min(width, roi.x + roi.width)
+            y2 = min(height, roi.y + roi.height)
+            crop_h, crop_w = y2 - y1, x2 - x1
+
+            mask = np.zeros((crop_h, crop_w), dtype=np.uint8)
+            contour = np.array([[p[0] - x1, p[1] - y1] for p in roi.points], dtype=np.int32)
+            cv2.fillPoly(mask, [contour], 255)
+
+            cropped_stack = np.zeros((num_frames, crop_h, crop_w), dtype=image_stack.dtype)
+            for i in range(num_frames):
+                frame = image_stack[i, y1:y2, x1:x2].copy()
+                cropped_stack[i] = cv2.bitwise_and(frame, frame, mask=mask)
+
+            self.log_processing_step("crop", {"roi": roi.to_dict(), "apply_mask": apply_mask})
+            return cropped_stack
+
+        # For rectangle and ellipse ROIs, delegate per-frame (mask doesn't vary)
         first_cropped = self.crop_to_roi(image_stack[0], roi, apply_mask)
 
-        # Allocate output array
         cropped_stack = np.zeros(
             (num_frames, first_cropped.shape[0], first_cropped.shape[1]),
             dtype=image_stack.dtype,
         )
         cropped_stack[0] = first_cropped
 
-        # Crop remaining frames
         for i in range(1, num_frames):
             cropped_stack[i] = self.crop_to_roi(image_stack[i], roi, apply_mask)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""
+Pytest configuration and session-wide fixtures.
+
+Qt-backend segfault prevention
+-------------------------------
+lomb_scargle_plot.py imports FigureCanvasQTAgg / NavigationToolbar2QT directly
+from matplotlib.backends.backend_qtagg at module level.  Importing that module
+triggers a two-stage crash:
+
+  Stage 1  backend_qt.py:14 pulls in matplotlib.backends.qt_editor.figureoptions
+           → qt_editor/_formlayout.py:59 defines class ColorButton(QPushButton)
+             with a QtCore.Signal — Qt GUI code executed at class-definition time.
+
+  Stage 2  backend_qt.py:216 defines class FigureCanvasQT(QWidget).
+           On macOS, PySide6's Shiboken metaclass calls into the Cocoa platform
+           plugin at the moment any QWidget subclass is first defined in Python.
+           That call segfaults unless a QApplication already exists.
+
+Two complementary fixes (test-infrastructure only; no src/ files touched):
+
+  1. Stub matplotlib.backends.qt_editor.figureoptions (and siblings) in
+     sys.modules so the _formlayout.py import chain never runs (Stage 1).
+
+  2. Create a QApplication singleton here, before any test module is collected,
+     so the platform plugin is initialised when FigureCanvasQT is defined
+     (Stage 2).  The widget tests that declare an `app` fixture check
+     QApplication.instance() first, so they reuse this same singleton.
+
+MPLBACKEND=Agg (set via pytest-env in pyproject.toml) additionally ensures that
+matplotlib.pyplot never auto-selects the Qt backend during normal test execution.
+"""
+
+import sys
+import unittest.mock
+
+# ── Stage 1: stub the Qt figure-options editor ────────────────────────────────
+# These modules are only used at runtime when the toolbar "Edit curves" button is
+# clicked — they are never triggered in tests.  Stubbing them prevents _formlayout
+# from being imported (and trying to define Signal-bearing Qt classes) before any
+# QApplication exists.
+_QT_EDITOR_STUBS = [
+    "matplotlib.backends.qt_editor",
+    "matplotlib.backends.qt_editor.figureoptions",
+    "matplotlib.backends.qt_editor._formlayout",
+]
+for _mod in _QT_EDITOR_STUBS:
+    sys.modules.setdefault(_mod, unittest.mock.MagicMock())
+
+# ── Stage 2: create QApplication before collection ───────────────────────────
+# PySide6 requires QApplication to exist before the first QWidget subclass is
+# defined at the Python level (macOS Cocoa initialisation).  Creating it here
+# means it is in place by the time backend_qt.py defines FigureCanvasQT.
+try:
+    from PySide6.QtWidgets import QApplication
+
+    if not QApplication.instance():
+        _qapp = QApplication(sys.argv or [""])
+except Exception:
+    # Non-graphical / headless environments: fall back gracefully.
+    # Tests that actually render widgets will be skipped or fail on their own.
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,16 @@ try:
 
     if not QApplication.instance():
         _qapp = QApplication(sys.argv or [""])
-except Exception:
-    # Non-graphical / headless environments: fall back gracefully.
+except (ImportError, RuntimeError):
+    # PySide6 not installed, or Qt platform plugin unavailable (headless CI).
     # Tests that actually render widgets will be skipped or fail on their own.
     pass
+except Exception:
+    import warnings
+
+    warnings.warn(
+        "Unexpected error during QApplication setup — check your Qt/PySide6 installation.",
+        RuntimeWarning,
+        stacklevel=1,
+    )
+    raise

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,5 +1,8 @@
 import cv2
 import numpy as np
+import pytest
+import tifffile
+from PIL import Image
 
 from core.experiment_manager import Experiment
 from core.image_processor import ImageProcessor
@@ -9,6 +12,8 @@ from core.roi import ROI, ROIShape
 def _make_processor() -> ImageProcessor:
     return ImageProcessor(Experiment(name="demo"))
 
+
+# ── crop_to_roi ───────────────────────────────────────────────────────────────
 
 def test_crop_to_roi_polygon_masks_outside_pixels():
     processor = _make_processor()
@@ -43,6 +48,33 @@ def test_crop_to_roi_ellipse_on_rgb_image():
     assert np.all(cropped[0, 0] == 0)
 
 
+def test_crop_to_roi_raises_for_4d_image():
+    processor = _make_processor()
+    image = np.zeros((5, 5, 3, 2), dtype=np.uint8)
+    roi = ROI(x=0, y=0, width=3, height=3, shape=ROIShape.ELLIPSE)
+    with pytest.raises(ValueError, match="Image must be 2D or 3D array"):
+        processor.crop_to_roi(image, roi)
+
+
+def test_crop_to_roi_no_mask_returns_full_slice():
+    processor = _make_processor()
+    image = np.ones((10, 10), dtype=np.uint8) * 5
+    roi = ROI(x=2, y=2, width=4, height=4, shape=ROIShape.ELLIPSE)
+    result = processor.crop_to_roi(image, roi, apply_mask=False)
+    assert result.shape == (4, 4)
+    assert np.all(result == 5)
+
+
+def test_crop_to_roi_ellipse_zero_rx_skips_mask():
+    processor = _make_processor()
+    image = np.ones((10, 10), dtype=np.uint8) * 7
+    roi = ROI(x=2, y=2, width=0, height=4, shape=ROIShape.ELLIPSE)
+    result = processor.crop_to_roi(image, roi, apply_mask=True)
+    assert result.shape[0] == 4
+
+
+# ── crop_stack_to_roi ─────────────────────────────────────────────────────────
+
 def test_crop_stack_to_roi_applies_crop_to_each_frame():
     processor = _make_processor()
     stack = np.stack([np.full((8, 8), fill_value=i, dtype=np.uint8) for i in range(3)])
@@ -55,6 +87,96 @@ def test_crop_stack_to_roi_applies_crop_to_each_frame():
     assert np.array_equal(cropped_stack[2], processor.crop_to_roi(stack[2], roi, apply_mask=False))
 
 
+def test_crop_stack_to_roi_raises_for_2d_input():
+    processor = _make_processor()
+    with pytest.raises(ValueError, match="Image stack must be 3D"):
+        processor.crop_stack_to_roi(np.zeros((5, 5), dtype=np.uint8), ROI(x=0, y=0, width=3, height=3))
+
+
+def test_crop_stack_to_roi_polygon_computes_mask_once():
+    processor = _make_processor()
+    stack = np.full((3, 10, 10), 100, dtype=np.uint8)
+    roi = ROI(
+        x=2, y=2, width=5, height=5,
+        shape=ROIShape.POLYGON,
+        points=[(2, 2), (7, 2), (4, 7)],
+    )
+    result = processor.crop_stack_to_roi(stack, roi, apply_mask=True)
+    assert result.shape == (3, 5, 5)
+    assert result[0, 1, 1] == 100
+    assert result[1, 1, 1] == 100
+    assert result[2, 1, 1] == 100
+    assert result[0, 4, 4] == 0
+
+
+def test_crop_stack_to_roi_ellipse_with_mask():
+    processor = _make_processor()
+    stack = np.full((2, 12, 12), 50, dtype=np.uint8)
+    roi = ROI(x=2, y=2, width=6, height=6, shape=ROIShape.ELLIPSE)
+    result = processor.crop_stack_to_roi(stack, roi, apply_mask=True)
+    assert result.shape == (2, 6, 6)
+    assert result[0, 3, 3] == 50
+
+
+# ── load_image ────────────────────────────────────────────────────────────────
+
+def test_load_image_returns_array(tmp_path):
+    path = tmp_path / "frame.png"
+    cv2.imwrite(str(path), np.zeros((10, 10), dtype=np.uint8))
+    processor = _make_processor()
+    img = processor.load_image(str(path))
+    assert img.shape == (10, 10)
+
+
+def test_load_image_raises_for_missing_file():
+    processor = _make_processor()
+    with pytest.raises(FileNotFoundError):
+        processor.load_image("/nonexistent/path/image.png")
+
+
+# ── preprocess_image ──────────────────────────────────────────────────────────
+
+def test_preprocess_image_blurs_image():
+    processor = _make_processor()
+    image = np.random.randint(0, 255, (20, 20), dtype=np.uint8)
+    result = processor.preprocess_image(image, {"ksize": 3})
+    assert result.shape == image.shape
+
+
+def test_preprocess_image_uses_default_ksize():
+    processor = _make_processor()
+    result = processor.preprocess_image(np.zeros((10, 10), dtype=np.uint8), {})
+    assert result.shape == (10, 10)
+
+
+# ── apply_opencv_filter ───────────────────────────────────────────────────────
+
+def test_apply_opencv_filter_edges():
+    processor = _make_processor()
+    image = np.zeros((20, 20), dtype=np.uint8)
+    result = processor.apply_opencv_filter(image, "edges")
+    assert result.shape == (20, 20)
+
+
+def test_apply_opencv_filter_unknown_returns_input():
+    processor = _make_processor()
+    image = np.ones((10, 10), dtype=np.uint8) * 42
+    result = processor.apply_opencv_filter(image, "unknown")
+    assert np.array_equal(result, image)
+
+
+# ── detect_objects / extract_features placeholders ───────────────────────────
+
+def test_detect_objects_returns_empty_list():
+    assert _make_processor().detect_objects(np.zeros((10, 10), dtype=np.uint8)) == []
+
+
+def test_extract_features_returns_empty_dict():
+    assert _make_processor().extract_features(np.zeros((10, 10), dtype=np.uint8)) == {}
+
+
+# ── detect_neurons ────────────────────────────────────────────────────────────
+
 def test_detect_neurons_returns_bright_spot_centroids():
     processor = _make_processor()
     image = np.zeros((50, 50), dtype=np.uint8)
@@ -65,3 +187,308 @@ def test_detect_neurons_returns_bright_spot_centroids():
 
     assert len(neurons) == 2
     assert {(x, y) for x, y in neurons} == {(10, 10), (35, 35)}
+
+
+def test_detect_neurons_normalizes_non_uint8():
+    processor = _make_processor()
+    image = np.zeros((50, 50), dtype=np.uint16)
+    image[10, 10] = 60000
+    neurons = processor.detect_neurons(image, threshold_percentile=95, min_area=1, max_area=50)
+    assert isinstance(neurons, list)
+
+
+# ── load_image_for_alignment ──────────────────────────────────────────────────
+
+def test_load_image_for_alignment_2d_tiff(tmp_path):
+    img = np.random.randint(0, 1000, (20, 20), dtype=np.uint16)
+    path = tmp_path / "frame.tif"
+    tifffile.imwrite(str(path), img)
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+    assert result.shape == (20, 20)
+
+
+def test_load_image_for_alignment_single_page_3d_tiff(tmp_path):
+    img = np.random.randint(0, 255, (1, 20, 20), dtype=np.uint8)
+    path = tmp_path / "single.tif"
+    tifffile.imwrite(str(path), img)
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+    assert result.shape == (20, 20)
+
+
+def test_load_image_for_alignment_multipage_tiff_raises(tmp_path):
+    img = np.random.randint(0, 255, (5, 20, 20), dtype=np.uint8)
+    path = tmp_path / "multi.tif"
+    tifffile.imwrite(str(path), img)
+    with pytest.raises(ValueError, match="Multi-page TIFF detected"):
+        _make_processor().load_image_for_alignment(str(path))
+
+
+def test_load_image_for_alignment_rgb_tiff(tmp_path):
+    img = (np.random.rand(20, 20, 3) * 255).astype(np.uint8)
+    path = tmp_path / "rgb.tif"
+    tifffile.imwrite(str(path), img)
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+    assert result.shape == (20, 20)
+
+
+def test_load_image_for_alignment_rgba_tiff(tmp_path):
+    img = (np.random.rand(20, 20, 4) * 255).astype(np.uint8)
+    path = tmp_path / "rgba.tif"
+    tifffile.imwrite(str(path), img)
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+    assert result.shape == (20, 20)
+
+
+def test_load_image_for_alignment_multichannel_tiff_takes_first(tmp_path):
+    img = (np.random.rand(20, 20, 5) * 255).astype(np.uint8)
+    path = tmp_path / "multi_ch.tif"
+    tifffile.imwrite(str(path), img)
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+    assert result.shape == (20, 20)
+
+
+def test_load_image_for_alignment_png_via_pil(tmp_path):
+    img = Image.fromarray(np.ones((20, 20), dtype=np.uint8) * 128, "L")
+    path = tmp_path / "gray.png"
+    img.save(str(path))
+    result = _make_processor().load_image_for_alignment(str(path))
+    assert result.ndim == 2
+
+
+def test_load_image_for_alignment_bad_tiff_raises(tmp_path):
+    with pytest.raises(ValueError, match="Failed to load"):
+        _make_processor().load_image_for_alignment(str(tmp_path / "no_such.tif"))
+
+
+def test_load_image_for_alignment_bad_png_raises(tmp_path):
+    with pytest.raises(ValueError, match="Failed to load"):
+        _make_processor().load_image_for_alignment(str(tmp_path / "no_such.png"))
+
+
+def test_load_image_for_alignment_1d_raises(tmp_path, monkeypatch):
+    import tifffile as tf
+    monkeypatch.setattr(tf, "imread", lambda *a, **kw: np.array([1, 2, 3]))
+    path = tmp_path / "fake.tif"
+    path.touch()
+    with pytest.raises(ValueError, match="1D array not supported"):
+        _make_processor().load_image_for_alignment(str(path))
+
+
+def test_load_image_for_alignment_4d_raises(tmp_path, monkeypatch):
+    import tifffile as tf
+    monkeypatch.setattr(tf, "imread", lambda *a, **kw: np.zeros((2, 10, 10, 3), dtype=np.uint8))
+    path = tmp_path / "fake.tif"
+    path.touch()
+    with pytest.raises(ValueError, match="Unsupported image dimensions"):
+        _make_processor().load_image_for_alignment(str(path))
+
+
+# ── align_image_stack ─────────────────────────────────────────────────────────
+
+def _small_stack(frames=3, h=16, w=16, dtype=np.uint8):
+    rng = np.random.default_rng(0)
+    return rng.integers(50, 200, (frames, h, w), dtype=dtype)
+
+
+def test_align_image_stack_raises_for_non_3d():
+    with pytest.raises(ValueError, match="Image stack must be 3D"):
+        _make_processor().align_image_stack(np.zeros((16, 16), dtype=np.uint8))
+
+
+def test_align_image_stack_first_reference():
+    stack = _small_stack()
+    aligned, tmats, scores = _make_processor().align_image_stack(stack, reference="first")
+    assert aligned.shape == stack.shape
+    assert len(scores) == 3
+    assert scores[0] == 1.0
+
+
+def test_align_image_stack_previous_reference():
+    stack = _small_stack()
+    aligned, tmats, scores = _make_processor().align_image_stack(stack, reference="previous")
+    assert aligned.shape == stack.shape
+    assert scores[0] == 1.0
+
+
+def test_align_image_stack_mean_reference():
+    stack = _small_stack()
+    aligned, tmats, scores = _make_processor().align_image_stack(stack, reference="mean")
+    assert aligned.shape == stack.shape
+    assert len(scores) == 3
+
+
+
+def test_align_image_stack_flat_stack_skips_normalization():
+    stack = np.full((3, 16, 16), 100, dtype=np.uint8)
+    aligned, tmats, scores = _make_processor().align_image_stack(stack, reference="first")
+    assert aligned.shape == stack.shape
+
+
+def test_align_image_stack_uint16_dtype():
+    stack = _small_stack(dtype=np.uint16)
+    aligned, tmats, scores = _make_processor().align_image_stack(stack)
+    assert aligned.dtype == np.uint16
+
+
+def test_align_image_stack_progress_callback_called():
+    stack = _small_stack()
+    calls = []
+
+    def cb(done, total, msg):
+        calls.append(msg)
+        return True
+
+    _make_processor().align_image_stack(stack, progress_callback=cb)
+    assert len(calls) > 0
+
+
+def test_align_image_stack_progress_callback_cancel_returns_early():
+    stack = _small_stack()
+
+    aligned, tmats, scores = _make_processor().align_image_stack(
+        stack, progress_callback=lambda *_: False
+    )
+    assert aligned.shape == stack.shape
+    assert scores == []
+
+
+# ── detect_neurons_in_roi ─────────────────────────────────────────────────────
+
+def _neuron_stack(frames=5, h=20, w=20, spots=None):
+    """Return a synthetic image stack with bright spots at given (y, x) positions."""
+    stack = np.zeros((frames, h, w), dtype=np.uint16)
+    for y, x in (spots or []):
+        for f in range(frames):
+            stack[f, y, x] = 1000
+            if x + 1 < w:
+                stack[f, y, x + 1] = 600
+            if y + 1 < h:
+                stack[f, y + 1, x] = 600
+    return stack
+
+
+def test_detect_neurons_in_roi_empty_mask_returns_empty():
+    processor = _make_processor()
+    stack = _neuron_stack(spots=[(5, 5)])
+    roi_mask = np.zeros((20, 20), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(stack, roi_mask)
+    assert locs.shape == (0, 2)
+    assert trajs.shape[0] == 0
+    assert quality.shape[0] == 0
+
+
+def test_detect_neurons_in_roi_no_peaks_returns_empty():
+    # Image too small for any peak to survive exclude_border
+    processor = _make_processor()
+    stack = np.random.randint(0, 255, (3, 4, 4), dtype=np.uint8)
+    roi_mask = np.ones((4, 4), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=6, threshold_rel=0.01
+    )
+    assert locs.shape == (0, 2)
+
+
+def test_detect_neurons_in_roi_single_neuron_quality_true():
+    processor = _make_processor()
+    stack = _neuron_stack(spots=[(10, 10)])
+    roi_mask = np.ones((20, 20), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, num_peaks=5,
+        correlation_threshold=0.0, threshold_rel=0.1, apply_detrending=False,
+    )
+    assert len(quality) == 1
+    assert quality[0] is True or quality[0] == True  # noqa: E712
+
+
+def test_detect_neurons_in_roi_basic_detection():
+    processor = _make_processor()
+    # Two bright spots far apart so both are detected
+    stack = _neuron_stack(h=30, w=30, spots=[(5, 5), (22, 22)])
+    roi_mask = np.ones((30, 30), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, num_peaks=10,
+        correlation_threshold=-1.0, threshold_rel=0.1, apply_detrending=False,
+    )
+    assert locs.shape[1] == 2
+    assert trajs.shape[1] == 5
+
+
+def test_detect_neurons_in_roi_uniform_frame_zeros_projection():
+    processor = _make_processor()
+    # All-same-value frames → frame_max == frame_min → zeros_like branch
+    stack = np.full((3, 15, 15), 50, dtype=np.uint8)
+    roi_mask = np.ones((15, 15), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, threshold_rel=0.01
+    )
+    assert isinstance(locs, np.ndarray)
+
+
+def test_detect_neurons_in_roi_with_detrending():
+    processor = _make_processor()
+    num_frames = 80
+    stack = np.zeros((num_frames, 20, 20), dtype=np.uint16)
+    stack[:, 10, 10] = 1000
+    roi_mask = np.ones((20, 20), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, num_peaks=5,
+        correlation_threshold=0.0, threshold_rel=0.1, apply_detrending=True,
+    )
+    assert isinstance(trajs, np.ndarray)
+
+
+def test_detect_neurons_in_roi_raises_for_2d_frame_data():
+    processor = _make_processor()
+    with pytest.raises(ValueError, match="frame_data must be a 3D array"):
+        processor.detect_neurons_in_roi(np.zeros((20, 20)), np.ones((20, 20), dtype=bool))
+
+
+def test_detect_neurons_in_roi_raises_for_3d_roi_mask():
+    processor = _make_processor()
+    with pytest.raises(ValueError, match="roi_mask must be a 2D array"):
+        processor.detect_neurons_in_roi(
+            np.zeros((3, 20, 20), dtype=np.uint8),
+            np.ones((3, 20, 20), dtype=bool),
+        )
+
+
+def test_detect_neurons_in_roi_raises_for_shape_mismatch():
+    processor = _make_processor()
+    with pytest.raises(ValueError, match="roi_mask shape"):
+        processor.detect_neurons_in_roi(
+            np.zeros((3, 20, 20), dtype=np.uint8),
+            np.ones((15, 15), dtype=bool),
+        )
+
+
+def test_detect_neurons_in_roi_with_progress_callback():
+    processor = _make_processor()
+    stack = _neuron_stack(spots=[(10, 10)])
+    roi_mask = np.ones((20, 20), dtype=bool)
+    calls = []
+
+    def cb(step, total, msg):
+        calls.append(step)
+
+    processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, num_peaks=5,
+        correlation_threshold=0.0, threshold_rel=0.1,
+        apply_detrending=False, progress_callback=cb,
+    )
+    assert len(calls) > 0
+
+
+def test_detect_neurons_in_roi_mean_projection():
+    processor = _make_processor()
+    stack = _neuron_stack(spots=[(10, 10)])
+    roi_mask = np.ones((20, 20), dtype=bool)
+    locs, trajs, quality = processor.detect_neurons_in_roi(
+        stack, roi_mask, cell_size=3, num_peaks=5,
+        threshold_rel=0.1, use_max_projection=False, apply_detrending=False,
+    )
+    assert isinstance(locs, np.ndarray)

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -15,6 +15,7 @@ def _make_processor() -> ImageProcessor:
 
 # ── crop_to_roi ───────────────────────────────────────────────────────────────
 
+
 def test_crop_to_roi_polygon_masks_outside_pixels():
     processor = _make_processor()
     image = np.zeros((10, 10), dtype=np.uint8)
@@ -75,6 +76,7 @@ def test_crop_to_roi_ellipse_zero_rx_skips_mask():
 
 # ── crop_stack_to_roi ─────────────────────────────────────────────────────────
 
+
 def test_crop_stack_to_roi_applies_crop_to_each_frame():
     processor = _make_processor()
     stack = np.stack([np.full((8, 8), fill_value=i, dtype=np.uint8) for i in range(3)])
@@ -97,7 +99,10 @@ def test_crop_stack_to_roi_polygon_computes_mask_once():
     processor = _make_processor()
     stack = np.full((3, 10, 10), 100, dtype=np.uint8)
     roi = ROI(
-        x=2, y=2, width=5, height=5,
+        x=2,
+        y=2,
+        width=5,
+        height=5,
         shape=ROIShape.POLYGON,
         points=[(2, 2), (7, 2), (4, 7)],
     )
@@ -120,6 +125,7 @@ def test_crop_stack_to_roi_ellipse_with_mask():
 
 # ── load_image ────────────────────────────────────────────────────────────────
 
+
 def test_load_image_returns_array(tmp_path):
     path = tmp_path / "frame.png"
     cv2.imwrite(str(path), np.zeros((10, 10), dtype=np.uint8))
@@ -136,6 +142,7 @@ def test_load_image_raises_for_missing_file():
 
 # ── preprocess_image ──────────────────────────────────────────────────────────
 
+
 def test_preprocess_image_blurs_image():
     processor = _make_processor()
     image = np.random.randint(0, 255, (20, 20), dtype=np.uint8)
@@ -150,6 +157,7 @@ def test_preprocess_image_uses_default_ksize():
 
 
 # ── apply_opencv_filter ───────────────────────────────────────────────────────
+
 
 def test_apply_opencv_filter_edges():
     processor = _make_processor()
@@ -167,6 +175,7 @@ def test_apply_opencv_filter_unknown_returns_input():
 
 # ── detect_objects / extract_features placeholders ───────────────────────────
 
+
 def test_detect_objects_returns_empty_list():
     assert _make_processor().detect_objects(np.zeros((10, 10), dtype=np.uint8)) == []
 
@@ -176,6 +185,7 @@ def test_extract_features_returns_empty_dict():
 
 
 # ── detect_neurons ────────────────────────────────────────────────────────────
+
 
 def test_detect_neurons_returns_bright_spot_centroids():
     processor = _make_processor()
@@ -198,6 +208,7 @@ def test_detect_neurons_normalizes_non_uint8():
 
 
 # ── load_image_for_alignment ──────────────────────────────────────────────────
+
 
 def test_load_image_for_alignment_2d_tiff(tmp_path):
     img = np.random.randint(0, 1000, (20, 20), dtype=np.uint16)
@@ -272,6 +283,7 @@ def test_load_image_for_alignment_bad_png_raises(tmp_path):
 
 def test_load_image_for_alignment_1d_raises(tmp_path, monkeypatch):
     import tifffile as tf
+
     monkeypatch.setattr(tf, "imread", lambda *a, **kw: np.array([1, 2, 3]))
     path = tmp_path / "fake.tif"
     path.touch()
@@ -281,6 +293,7 @@ def test_load_image_for_alignment_1d_raises(tmp_path, monkeypatch):
 
 def test_load_image_for_alignment_4d_raises(tmp_path, monkeypatch):
     import tifffile as tf
+
     monkeypatch.setattr(tf, "imread", lambda *a, **kw: np.zeros((2, 10, 10, 3), dtype=np.uint8))
     path = tmp_path / "fake.tif"
     path.touch()
@@ -289,6 +302,7 @@ def test_load_image_for_alignment_4d_raises(tmp_path, monkeypatch):
 
 
 # ── align_image_stack ─────────────────────────────────────────────────────────
+
 
 def _small_stack(frames=3, h=16, w=16, dtype=np.uint8):
     rng = np.random.default_rng(0)
@@ -322,7 +336,6 @@ def test_align_image_stack_mean_reference():
     assert len(scores) == 3
 
 
-
 def test_align_image_stack_flat_stack_skips_normalization():
     stack = np.full((3, 16, 16), 100, dtype=np.uint8)
     aligned, tmats, scores = _make_processor().align_image_stack(stack, reference="first")
@@ -350,19 +363,18 @@ def test_align_image_stack_progress_callback_called():
 def test_align_image_stack_progress_callback_cancel_returns_early():
     stack = _small_stack()
 
-    aligned, tmats, scores = _make_processor().align_image_stack(
-        stack, progress_callback=lambda *_: False
-    )
+    aligned, tmats, scores = _make_processor().align_image_stack(stack, progress_callback=lambda *_: False)
     assert aligned.shape == stack.shape
     assert scores == []
 
 
 # ── detect_neurons_in_roi ─────────────────────────────────────────────────────
 
+
 def _neuron_stack(frames=5, h=20, w=20, spots=None):
     """Return a synthetic image stack with bright spots at given (y, x) positions."""
     stack = np.zeros((frames, h, w), dtype=np.uint16)
-    for y, x in (spots or []):
+    for y, x in spots or []:
         for f in range(frames):
             stack[f, y, x] = 1000
             if x + 1 < w:
@@ -387,9 +399,7 @@ def test_detect_neurons_in_roi_no_peaks_returns_empty():
     processor = _make_processor()
     stack = np.random.randint(0, 255, (3, 4, 4), dtype=np.uint8)
     roi_mask = np.ones((4, 4), dtype=bool)
-    locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=6, threshold_rel=0.01
-    )
+    locs, trajs, quality = processor.detect_neurons_in_roi(stack, roi_mask, cell_size=6, threshold_rel=0.01)
     assert locs.shape == (0, 2)
 
 
@@ -398,8 +408,13 @@ def test_detect_neurons_in_roi_single_neuron_quality_true():
     stack = _neuron_stack(spots=[(10, 10)])
     roi_mask = np.ones((20, 20), dtype=bool)
     locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, num_peaks=5,
-        correlation_threshold=0.0, threshold_rel=0.1, apply_detrending=False,
+        stack,
+        roi_mask,
+        cell_size=3,
+        num_peaks=5,
+        correlation_threshold=0.0,
+        threshold_rel=0.1,
+        apply_detrending=False,
     )
     assert len(quality) == 1
     assert quality[0] is True or quality[0] == True  # noqa: E712
@@ -411,8 +426,13 @@ def test_detect_neurons_in_roi_basic_detection():
     stack = _neuron_stack(h=30, w=30, spots=[(5, 5), (22, 22)])
     roi_mask = np.ones((30, 30), dtype=bool)
     locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, num_peaks=10,
-        correlation_threshold=-1.0, threshold_rel=0.1, apply_detrending=False,
+        stack,
+        roi_mask,
+        cell_size=3,
+        num_peaks=10,
+        correlation_threshold=-1.0,
+        threshold_rel=0.1,
+        apply_detrending=False,
     )
     assert locs.shape[1] == 2
     assert trajs.shape[1] == 5
@@ -423,9 +443,7 @@ def test_detect_neurons_in_roi_uniform_frame_zeros_projection():
     # All-same-value frames → frame_max == frame_min → zeros_like branch
     stack = np.full((3, 15, 15), 50, dtype=np.uint8)
     roi_mask = np.ones((15, 15), dtype=bool)
-    locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, threshold_rel=0.01
-    )
+    locs, trajs, quality = processor.detect_neurons_in_roi(stack, roi_mask, cell_size=3, threshold_rel=0.01)
     assert isinstance(locs, np.ndarray)
 
 
@@ -436,8 +454,13 @@ def test_detect_neurons_in_roi_with_detrending():
     stack[:, 10, 10] = 1000
     roi_mask = np.ones((20, 20), dtype=bool)
     locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, num_peaks=5,
-        correlation_threshold=0.0, threshold_rel=0.1, apply_detrending=True,
+        stack,
+        roi_mask,
+        cell_size=3,
+        num_peaks=5,
+        correlation_threshold=0.0,
+        threshold_rel=0.1,
+        apply_detrending=True,
     )
     assert isinstance(trajs, np.ndarray)
 
@@ -476,9 +499,14 @@ def test_detect_neurons_in_roi_with_progress_callback():
         calls.append(step)
 
     processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, num_peaks=5,
-        correlation_threshold=0.0, threshold_rel=0.1,
-        apply_detrending=False, progress_callback=cb,
+        stack,
+        roi_mask,
+        cell_size=3,
+        num_peaks=5,
+        correlation_threshold=0.0,
+        threshold_rel=0.1,
+        apply_detrending=False,
+        progress_callback=cb,
     )
     assert len(calls) > 0
 
@@ -488,7 +516,12 @@ def test_detect_neurons_in_roi_mean_projection():
     stack = _neuron_stack(spots=[(10, 10)])
     roi_mask = np.ones((20, 20), dtype=bool)
     locs, trajs, quality = processor.detect_neurons_in_roi(
-        stack, roi_mask, cell_size=3, num_peaks=5,
-        threshold_rel=0.1, use_max_projection=False, apply_detrending=False,
+        stack,
+        roi_mask,
+        cell_size=3,
+        num_peaks=5,
+        threshold_rel=0.1,
+        use_max_projection=False,
+        apply_detrending=False,
     )
     assert isinstance(locs, np.ndarray)

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -27,7 +27,7 @@ def test_crop_to_roi_polygon_masks_outside_pixels():
 
     assert cropped.shape == (5, 5)
     assert cropped[1, 1] == 100
-    assert cropped[0, -1] == 0
+    assert cropped[4, 4] == 0  # clearly outside triangle (right of right edge at y=4)
 
 
 def test_crop_to_roi_ellipse_on_rgb_image():

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -11,7 +11,6 @@ from PySide6.QtGui import QImage
 
 from utils.image_utils import numpy_to_qimage
 
-
 # ---------------------------------------------------------------------------
 # 2-D grayscale — uint8
 # ---------------------------------------------------------------------------

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,161 +1,148 @@
-"""Tests for src/utils/image_utils.py — numpy_to_qimage."""
+"""Tests for src/utils/image_utils.py — numpy_to_qimage.
 
-import sys
-import unittest.mock
+PySide6 is available in this environment (QApplication is created by conftest.py),
+so tests use the real QImage rather than a sys.modules-level mock.  QImage is a
+data container in QtGui and does not require QApplication to instantiate.
+"""
 
-# ---------------------------------------------------------------------------
-# Mock PySide6 before importing anything from the package
-# ---------------------------------------------------------------------------
-_qimage_mock = unittest.mock.MagicMock()
-_qimage_mock.Format_Grayscale8 = 1
-_qimage_mock.Format_Grayscale16 = 2
-_qimage_mock.Format_RGB888 = 3
-_qimage_mock.Format_RGBA8888 = 4
+import numpy as np
+import pytest
+from PySide6.QtGui import QImage
 
-_qtgui_mock = unittest.mock.MagicMock()
-_qtgui_mock.QImage = _qimage_mock
-
-sys.modules.setdefault("PySide6", unittest.mock.MagicMock())
-sys.modules["PySide6.QtGui"] = _qtgui_mock
-
-import importlib  # noqa: E402  (must come after sys.modules patching)
-import pytest  # noqa: E402
-import numpy as np  # noqa: E402
-
-# Force a clean import so the module sees our mocked PySide6
-if "utils.image_utils" in sys.modules:
-    del sys.modules["utils.image_utils"]
-from utils.image_utils import numpy_to_qimage  # noqa: E402
+from utils.image_utils import numpy_to_qimage
 
 
 # ---------------------------------------------------------------------------
 # 2-D grayscale — uint8
 # ---------------------------------------------------------------------------
 
-def test_2d_uint8_returns_qimage():
-    """2-D uint8 array should produce a Grayscale8 QImage without error."""
-    arr = np.array([[0, 128], [64, 255]], dtype=np.uint8)
+
+def test_2d_uint8_returns_qimage_instance():
+    """2-D uint8 array should return a real QImage instance."""
+    arr = np.zeros((4, 4), dtype=np.uint8)
     result = numpy_to_qimage(arr)
-    _qimage_mock.assert_called()
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 def test_2d_uint8_uses_grayscale8_format():
-    """2-D uint8 array must use Format_Grayscale8."""
+    """2-D uint8 array must be encoded with Format_Grayscale8."""
     arr = np.zeros((4, 4), dtype=np.uint8)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    _, kwargs = _qimage_mock.call_args_list[-1][0], _qimage_mock.call_args_list[-1][1]
-    call_args = _qimage_mock.call_args_list[-1][0]
-    # 5th positional arg is the format
-    assert call_args[4] == _qimage_mock.Format_Grayscale8
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_Grayscale8
+
+
+def test_2d_uint8_dimensions_match_array_shape():
+    """QImage width and height must match the array's (rows, cols) shape."""
+    arr = np.zeros((6, 8), dtype=np.uint8)
+    result = numpy_to_qimage(arr)
+    assert result.width() == 8
+    assert result.height() == 6
 
 
 def test_2d_uint8_single_pixel():
     """Single-pixel uint8 array must be handled without error."""
     arr = np.array([[42]], dtype=np.uint8)
     result = numpy_to_qimage(arr)
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 # ---------------------------------------------------------------------------
 # 2-D grayscale — uint16
 # ---------------------------------------------------------------------------
 
-def test_2d_uint16_returns_qimage():
-    """2-D uint16 array should produce a Grayscale16 QImage."""
+
+def test_2d_uint16_returns_qimage_instance():
+    """2-D uint16 array should return a real QImage instance."""
     arr = np.array([[0, 1000], [32768, 65535]], dtype=np.uint16)
     result = numpy_to_qimage(arr)
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 def test_2d_uint16_uses_grayscale16_format():
-    """2-D uint16 array must use Format_Grayscale16."""
+    """2-D uint16 array must be encoded with Format_Grayscale16."""
     arr = np.zeros((3, 3), dtype=np.uint16)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_Grayscale16
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_Grayscale16
 
 
 # ---------------------------------------------------------------------------
 # 2-D grayscale — other dtypes (normalization path)
 # ---------------------------------------------------------------------------
 
-def test_2d_float32_with_range_normalizes_to_uint8():
-    """float32 array with varying values should be normalized to uint8 Grayscale8."""
+
+def test_2d_float32_with_range_uses_grayscale8():
+    """float32 array with varying values is normalized and returned as Grayscale8."""
     arr = np.array([[0.0, 0.5], [0.25, 1.0]], dtype=np.float32)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_Grayscale8
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_Grayscale8
 
 
-def test_2d_float32_flat_array_uses_clip_path():
-    """float32 array where all values are equal should take the clip (hi==lo) path."""
+def test_2d_float32_flat_array_uses_grayscale8():
+    """float32 array where all values are equal (hi==lo clip path) returns Grayscale8."""
     arr = np.full((4, 4), 0.7, dtype=np.float32)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_Grayscale8
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_Grayscale8
 
 
-def test_2d_int16_normalizes_to_uint8():
+def test_2d_int16_normalized_to_grayscale8():
     """int16 array should be normalized and returned as Grayscale8."""
     arr = np.array([[-100, 0], [50, 200]], dtype=np.int16)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_Grayscale8
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_Grayscale8
 
 
-def test_2d_float64_single_pixel_flat():
-    """Single-pixel float64 array (hi == lo) uses the clip/flat branch."""
+def test_2d_float64_single_pixel_flat_clip_branch():
+    """Single-pixel float64 (hi==lo) takes the flat-clip branch and returns QImage."""
     arr = np.array([[3.14]], dtype=np.float64)
     result = numpy_to_qimage(arr)
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 # ---------------------------------------------------------------------------
 # 3-D RGB / RGBA
 # ---------------------------------------------------------------------------
 
-def test_3d_rgb_returns_qimage():
-    """3-channel uint8 array should produce an RGB888 QImage."""
+
+def test_3d_rgb_returns_qimage_instance():
+    """3-channel uint8 array should return a real QImage instance."""
     arr = np.zeros((10, 10, 3), dtype=np.uint8)
-    arr[0, 0] = [255, 0, 0]
     result = numpy_to_qimage(arr)
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 def test_3d_rgb_uses_rgb888_format():
-    """3-channel array must use Format_RGB888."""
+    """3-channel array must be encoded with Format_RGB888."""
     arr = np.ones((5, 5, 3), dtype=np.uint8)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_RGB888
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_RGB888
 
 
-def test_3d_rgba_returns_qimage():
-    """4-channel uint8 array should produce an RGBA8888 QImage."""
+def test_3d_rgb_dimensions_match_array_shape():
+    """QImage width and height must match the 3-channel array's spatial dimensions."""
+    arr = np.zeros((5, 7, 3), dtype=np.uint8)
+    result = numpy_to_qimage(arr)
+    assert result.width() == 7
+    assert result.height() == 5
+
+
+def test_3d_rgba_returns_qimage_instance():
+    """4-channel uint8 array should return a real QImage instance."""
     arr = np.zeros((8, 8, 4), dtype=np.uint8)
     result = numpy_to_qimage(arr)
-    assert result is not None
+    assert isinstance(result, QImage)
 
 
 def test_3d_rgba_uses_rgba8888_format():
-    """4-channel array must use Format_RGBA8888."""
+    """4-channel array must be encoded with Format_RGBA8888."""
     arr = np.ones((6, 6, 4), dtype=np.uint8) * 128
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[4] == _qimage_mock.Format_RGBA8888
+    result = numpy_to_qimage(arr)
+    assert result.format() == QImage.Format_RGBA8888
 
 
 # ---------------------------------------------------------------------------
 # Invalid / unsupported inputs → ValueError
 # ---------------------------------------------------------------------------
+
 
 def test_1d_array_raises_value_error():
     """1-D array is not a supported image shape and must raise ValueError."""
@@ -186,23 +173,19 @@ def test_3d_five_channel_raises_value_error():
 
 
 # ---------------------------------------------------------------------------
-# Stride correctness (bytes_per_line is passed)
+# Stride correctness — bytes_per_line must equal arr.strides[0]
 # ---------------------------------------------------------------------------
 
-def test_2d_uint8_stride_passed_to_qimage():
-    """bytes_per_line passed to QImage must equal arr.strides[0]."""
+
+def test_2d_uint8_bytes_per_line_matches_stride():
+    """bytes_per_line passed to QImage must equal arr.strides[0] for a 2-D array."""
     arr = np.zeros((10, 20), dtype=np.uint8)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    # call: QImage(data, w, h, bytes_per_line, fmt)
-    assert call_args[3] == arr.strides[0]
+    result = numpy_to_qimage(arr)
+    assert result.bytesPerLine() == arr.strides[0]
 
 
-def test_3d_rgb_stride_passed_to_qimage():
-    """bytes_per_line for RGB array must equal arr.strides[0]."""
+def test_3d_rgb_bytes_per_line_matches_stride():
+    """bytes_per_line for an RGB array must equal arr.strides[0]."""
     arr = np.zeros((7, 9, 3), dtype=np.uint8)
-    _qimage_mock.reset_mock()
-    numpy_to_qimage(arr)
-    call_args = _qimage_mock.call_args_list[-1][0]
-    assert call_args[3] == arr.strides[0]
+    result = numpy_to_qimage(arr)
+    assert result.bytesPerLine() == arr.strides[0]

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,0 +1,208 @@
+"""Tests for src/utils/image_utils.py — numpy_to_qimage."""
+
+import sys
+import unittest.mock
+
+# ---------------------------------------------------------------------------
+# Mock PySide6 before importing anything from the package
+# ---------------------------------------------------------------------------
+_qimage_mock = unittest.mock.MagicMock()
+_qimage_mock.Format_Grayscale8 = 1
+_qimage_mock.Format_Grayscale16 = 2
+_qimage_mock.Format_RGB888 = 3
+_qimage_mock.Format_RGBA8888 = 4
+
+_qtgui_mock = unittest.mock.MagicMock()
+_qtgui_mock.QImage = _qimage_mock
+
+sys.modules.setdefault("PySide6", unittest.mock.MagicMock())
+sys.modules["PySide6.QtGui"] = _qtgui_mock
+
+import importlib  # noqa: E402  (must come after sys.modules patching)
+import pytest  # noqa: E402
+import numpy as np  # noqa: E402
+
+# Force a clean import so the module sees our mocked PySide6
+if "utils.image_utils" in sys.modules:
+    del sys.modules["utils.image_utils"]
+from utils.image_utils import numpy_to_qimage  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 2-D grayscale — uint8
+# ---------------------------------------------------------------------------
+
+def test_2d_uint8_returns_qimage():
+    """2-D uint8 array should produce a Grayscale8 QImage without error."""
+    arr = np.array([[0, 128], [64, 255]], dtype=np.uint8)
+    result = numpy_to_qimage(arr)
+    _qimage_mock.assert_called()
+    assert result is not None
+
+
+def test_2d_uint8_uses_grayscale8_format():
+    """2-D uint8 array must use Format_Grayscale8."""
+    arr = np.zeros((4, 4), dtype=np.uint8)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    _, kwargs = _qimage_mock.call_args_list[-1][0], _qimage_mock.call_args_list[-1][1]
+    call_args = _qimage_mock.call_args_list[-1][0]
+    # 5th positional arg is the format
+    assert call_args[4] == _qimage_mock.Format_Grayscale8
+
+
+def test_2d_uint8_single_pixel():
+    """Single-pixel uint8 array must be handled without error."""
+    arr = np.array([[42]], dtype=np.uint8)
+    result = numpy_to_qimage(arr)
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# 2-D grayscale — uint16
+# ---------------------------------------------------------------------------
+
+def test_2d_uint16_returns_qimage():
+    """2-D uint16 array should produce a Grayscale16 QImage."""
+    arr = np.array([[0, 1000], [32768, 65535]], dtype=np.uint16)
+    result = numpy_to_qimage(arr)
+    assert result is not None
+
+
+def test_2d_uint16_uses_grayscale16_format():
+    """2-D uint16 array must use Format_Grayscale16."""
+    arr = np.zeros((3, 3), dtype=np.uint16)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_Grayscale16
+
+
+# ---------------------------------------------------------------------------
+# 2-D grayscale — other dtypes (normalization path)
+# ---------------------------------------------------------------------------
+
+def test_2d_float32_with_range_normalizes_to_uint8():
+    """float32 array with varying values should be normalized to uint8 Grayscale8."""
+    arr = np.array([[0.0, 0.5], [0.25, 1.0]], dtype=np.float32)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_Grayscale8
+
+
+def test_2d_float32_flat_array_uses_clip_path():
+    """float32 array where all values are equal should take the clip (hi==lo) path."""
+    arr = np.full((4, 4), 0.7, dtype=np.float32)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_Grayscale8
+
+
+def test_2d_int16_normalizes_to_uint8():
+    """int16 array should be normalized and returned as Grayscale8."""
+    arr = np.array([[-100, 0], [50, 200]], dtype=np.int16)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_Grayscale8
+
+
+def test_2d_float64_single_pixel_flat():
+    """Single-pixel float64 array (hi == lo) uses the clip/flat branch."""
+    arr = np.array([[3.14]], dtype=np.float64)
+    result = numpy_to_qimage(arr)
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# 3-D RGB / RGBA
+# ---------------------------------------------------------------------------
+
+def test_3d_rgb_returns_qimage():
+    """3-channel uint8 array should produce an RGB888 QImage."""
+    arr = np.zeros((10, 10, 3), dtype=np.uint8)
+    arr[0, 0] = [255, 0, 0]
+    result = numpy_to_qimage(arr)
+    assert result is not None
+
+
+def test_3d_rgb_uses_rgb888_format():
+    """3-channel array must use Format_RGB888."""
+    arr = np.ones((5, 5, 3), dtype=np.uint8)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_RGB888
+
+
+def test_3d_rgba_returns_qimage():
+    """4-channel uint8 array should produce an RGBA8888 QImage."""
+    arr = np.zeros((8, 8, 4), dtype=np.uint8)
+    result = numpy_to_qimage(arr)
+    assert result is not None
+
+
+def test_3d_rgba_uses_rgba8888_format():
+    """4-channel array must use Format_RGBA8888."""
+    arr = np.ones((6, 6, 4), dtype=np.uint8) * 128
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[4] == _qimage_mock.Format_RGBA8888
+
+
+# ---------------------------------------------------------------------------
+# Invalid / unsupported inputs → ValueError
+# ---------------------------------------------------------------------------
+
+def test_1d_array_raises_value_error():
+    """1-D array is not a supported image shape and must raise ValueError."""
+    arr = np.array([1, 2, 3], dtype=np.uint8)
+    with pytest.raises(ValueError, match="Unsupported image shape"):
+        numpy_to_qimage(arr)
+
+
+def test_3d_two_channel_raises_value_error():
+    """3-D array with 2 channels is unsupported and must raise ValueError."""
+    arr = np.zeros((4, 4, 2), dtype=np.uint8)
+    with pytest.raises(ValueError, match="Unsupported image shape"):
+        numpy_to_qimage(arr)
+
+
+def test_4d_array_raises_value_error():
+    """4-D array is not a supported image shape and must raise ValueError."""
+    arr = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="Unsupported image shape"):
+        numpy_to_qimage(arr)
+
+
+def test_3d_five_channel_raises_value_error():
+    """3-D array with 5 channels falls through all branches and raises ValueError."""
+    arr = np.zeros((4, 4, 5), dtype=np.uint8)
+    with pytest.raises(ValueError, match="Unsupported image shape"):
+        numpy_to_qimage(arr)
+
+
+# ---------------------------------------------------------------------------
+# Stride correctness (bytes_per_line is passed)
+# ---------------------------------------------------------------------------
+
+def test_2d_uint8_stride_passed_to_qimage():
+    """bytes_per_line passed to QImage must equal arr.strides[0]."""
+    arr = np.zeros((10, 20), dtype=np.uint8)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    # call: QImage(data, w, h, bytes_per_line, fmt)
+    assert call_args[3] == arr.strides[0]
+
+
+def test_3d_rgb_stride_passed_to_qimage():
+    """bytes_per_line for RGB array must equal arr.strides[0]."""
+    arr = np.zeros((7, 9, 3), dtype=np.uint8)
+    _qimage_mock.reset_mock()
+    numpy_to_qimage(arr)
+    call_args = _qimage_mock.call_args_list[-1][0]
+    assert call_args[3] == arr.strides[0]

--- a/tests/test_lomb_scargle_plot_widget.py
+++ b/tests/test_lomb_scargle_plot_widget.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 from unittest.mock import Mock, patch
 
 import numpy as np

--- a/tests/test_lomb_scargle_plot_widget.py
+++ b/tests/test_lomb_scargle_plot_widget.py
@@ -1,5 +1,6 @@
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 
 from unittest.mock import Mock, patch
 

--- a/tests/test_roi_geometry.py
+++ b/tests/test_roi_geometry.py
@@ -1,4 +1,6 @@
-from core.roi import ROI, ROIShape
+import pytest
+import numpy as np
+from core.roi import ROI, ROIHandle, ROIShape
 
 
 def test_roi_polygon_roundtrip_preserves_points_and_bounds():
@@ -45,3 +47,368 @@ def test_roi_contains_point_and_create_mask_work_for_both_shapes():
     assert ellipse_mask[0, 0] == 0
     assert polygon_mask[3, 3] == 255
     assert polygon_mask[0, 0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Lines 100–102: get_center() — polygon centroid branch
+# ---------------------------------------------------------------------------
+
+
+def test_get_center_polygon_returns_mean_of_vertices():
+    """Polygon get_center returns the arithmetic mean of all vertex coordinates."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (4, 0), (4, 4), (0, 4)],
+    )
+    cx, cy = roi.get_center()
+    assert cx == 2.0
+    assert cy == 2.0
+
+
+def test_get_center_polygon_triangle_centroid():
+    """Triangle centroid is computed as the mean of its three vertices."""
+    roi = ROI(
+        x=0, y=0, width=6, height=6,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (6, 0), (3, 6)],
+    )
+    cx, cy = roi.get_center()
+    assert cx == pytest.approx(3.0)
+    assert cy == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Line 125: contains_point() — zero-radius ellipse returns False immediately
+# ---------------------------------------------------------------------------
+
+
+def test_contains_point_zero_width_ellipse_returns_false():
+    """Ellipse with width=0 (rx=0) always returns False from contains_point."""
+    roi = ROI(x=5, y=5, width=0, height=10, shape=ROIShape.ELLIPSE)
+    assert roi.contains_point(5, 10) is False
+
+
+def test_contains_point_zero_height_ellipse_returns_false():
+    """Ellipse with height=0 (ry=0) always returns False from contains_point."""
+    roi = ROI(x=5, y=5, width=10, height=0, shape=ROIShape.ELLIPSE)
+    assert roi.contains_point(10, 5) is False
+
+
+# ---------------------------------------------------------------------------
+# Lines 136–156: get_handle_at_point() — polygon and ellipse paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_handle_at_point_polygon_vertex_hit_returns_vertex_tuple():
+    """A point on a polygon vertex returns (ROIHandle.VERTEX, index)."""
+    roi = ROI(
+        x=0, y=0, width=20, height=20,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (20, 0), (20, 20), (0, 20)],
+    )
+    result = roi.get_handle_at_point(0, 0)
+    assert result == (ROIHandle.VERTEX, 0)
+
+
+def test_get_handle_at_point_polygon_second_vertex_hit():
+    """A point on the second polygon vertex returns (VERTEX, 1)."""
+    roi = ROI(
+        x=0, y=0, width=20, height=20,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (20, 0), (20, 20), (0, 20)],
+    )
+    result = roi.get_handle_at_point(20, 0)
+    assert result == (ROIHandle.VERTEX, 1)
+
+
+def test_get_handle_at_point_polygon_inside_returns_move():
+    """A point inside the polygon (not on a vertex) returns MOVE."""
+    roi = ROI(
+        x=0, y=0, width=40, height=40,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (40, 0), (40, 40), (0, 40)],
+    )
+    result = roi.get_handle_at_point(20, 20)
+    assert result == ROIHandle.MOVE
+
+
+def test_get_handle_at_point_polygon_outside_returns_none():
+    """A point outside the polygon (and not on a vertex) returns NONE."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    result = roi.get_handle_at_point(50, 50)
+    assert result == ROIHandle.NONE
+
+
+def test_get_handle_at_point_ellipse_top_left_corner():
+    """A point exactly on the top-left corner of the ellipse bbox returns TOP_LEFT."""
+    roi = ROI(x=10, y=10, width=20, height=20, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(10, 10) == ROIHandle.TOP_LEFT
+
+
+def test_get_handle_at_point_ellipse_top_right_corner():
+    """A point on the top-right corner of the ellipse bbox returns TOP_RIGHT."""
+    roi = ROI(x=10, y=10, width=20, height=20, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(30, 10) == ROIHandle.TOP_RIGHT
+
+
+def test_get_handle_at_point_ellipse_bottom_left_corner():
+    """A point on the bottom-left corner of the ellipse bbox returns BOTTOM_LEFT."""
+    roi = ROI(x=10, y=10, width=20, height=20, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(10, 30) == ROIHandle.BOTTOM_LEFT
+
+
+def test_get_handle_at_point_ellipse_bottom_right_corner():
+    """A point on the bottom-right corner of the ellipse bbox returns BOTTOM_RIGHT."""
+    roi = ROI(x=10, y=10, width=20, height=20, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(30, 30) == ROIHandle.BOTTOM_RIGHT
+
+
+def test_get_handle_at_point_ellipse_center_returns_move():
+    """A point at the center of an ellipse (not near a corner) returns MOVE."""
+    roi = ROI(x=0, y=0, width=60, height=60, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(30, 30) == ROIHandle.MOVE
+
+
+def test_get_handle_at_point_ellipse_far_outside_returns_none():
+    """A point far outside the ellipse and corners returns NONE."""
+    roi = ROI(x=0, y=0, width=10, height=10, shape=ROIShape.ELLIPSE)
+    assert roi.get_handle_at_point(200, 200) == ROIHandle.NONE
+
+
+# ---------------------------------------------------------------------------
+# Lines 173–192: adjust_with_handle() — polygon branch
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_with_handle_polygon_move_shifts_all_vertices():
+    """MOVE handle shifts every polygon vertex by (dx, dy)."""
+    roi = ROI(
+        x=5, y=5, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(5, 5), (15, 5), (15, 15), (5, 15)],
+    )
+    roi.adjust_with_handle(ROIHandle.MOVE, 3, 2, 100, 100)
+    assert (8, 7) in roi.points
+    assert (18, 7) in roi.points
+    assert (18, 17) in roi.points
+    assert (8, 17) in roi.points
+
+
+def test_adjust_with_handle_polygon_move_clamps_to_image_bounds():
+    """MOVE handle clamps all polygon vertices so they stay within image bounds."""
+    roi = ROI(
+        x=0, y=0, width=5, height=5,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (5, 0), (5, 5), (0, 5)],
+    )
+    roi.adjust_with_handle(ROIHandle.MOVE, -100, -100, 100, 100)
+    for vx, vy in roi.points:
+        assert vx >= 0
+        assert vy >= 0
+
+
+def test_adjust_with_handle_polygon_vertex_moves_single_vertex():
+    """VERTEX handle with vertex_index moves only the specified vertex."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    roi.adjust_with_handle(ROIHandle.VERTEX, 2, 3, 100, 100, vertex_index=0)
+    assert roi.points[0] == (2, 3)
+    assert roi.points[1] == (10, 0)  # unchanged
+
+
+def test_adjust_with_handle_polygon_tuple_handle_unpacked_correctly():
+    """Tuple (VERTEX, index) handle is unpacked and moves the correct vertex."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    roi.adjust_with_handle((ROIHandle.VERTEX, 2), 1, 1, 100, 100)
+    assert roi.points[2] == (11, 11)
+    assert roi.points[0] == (0, 0)  # unchanged
+
+
+def test_adjust_with_handle_polygon_vertex_clamps_to_bounds():
+    """VERTEX handle clamps the moved vertex to [0, image_dim-1]."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    roi.adjust_with_handle(ROIHandle.VERTEX, -50, -50, 100, 100, vertex_index=0)
+    vx, vy = roi.points[0]
+    assert vx == 0 and vy == 0
+
+
+# ---------------------------------------------------------------------------
+# Lines 194–217: adjust_with_handle() — ellipse branch (all 5 handle cases)
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_with_handle_ellipse_move_shifts_position():
+    """MOVE handle on ellipse shifts x and y by (dx, dy)."""
+    roi = ROI(x=10, y=10, width=20, height=20, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.MOVE, 5, 3, 200, 200)
+    assert roi.x == 15
+    assert roi.y == 13
+
+
+def test_adjust_with_handle_ellipse_move_clamps_within_image():
+    """MOVE handle clamps ellipse position so it cannot leave image bounds."""
+    roi = ROI(x=0, y=0, width=20, height=20, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.MOVE, -100, -100, 200, 200)
+    assert roi.x == 0
+    assert roi.y == 0
+
+
+def test_adjust_with_handle_ellipse_top_left_resizes_from_top_left():
+    """TOP_LEFT handle moves the top-left corner and resizes width/height accordingly."""
+    roi = ROI(x=10, y=10, width=30, height=30, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.TOP_LEFT, 5, 5, 200, 200)
+    assert roi.x == 15
+    assert roi.y == 15
+    assert roi.width == 25
+    assert roi.height == 25
+
+
+def test_adjust_with_handle_ellipse_top_right_resizes():
+    """TOP_RIGHT handle expands width to the right and shrinks from the top."""
+    roi = ROI(x=10, y=10, width=30, height=30, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.TOP_RIGHT, 5, 5, 200, 200)
+    assert roi.y == 15
+    assert roi.width == 35
+    assert roi.height == 25
+
+
+def test_adjust_with_handle_ellipse_bottom_left_resizes():
+    """BOTTOM_LEFT handle moves left edge and expands height downward."""
+    roi = ROI(x=10, y=10, width=30, height=30, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.BOTTOM_LEFT, 5, 5, 200, 200)
+    assert roi.x == 15
+    assert roi.width == 25
+    assert roi.height == 35
+
+
+def test_adjust_with_handle_ellipse_bottom_right_resizes():
+    """BOTTOM_RIGHT handle expands both width and height to the bottom-right."""
+    roi = ROI(x=10, y=10, width=30, height=30, shape=ROIShape.ELLIPSE)
+    roi.adjust_with_handle(ROIHandle.BOTTOM_RIGHT, 5, 5, 200, 200)
+    assert roi.width == 35
+    assert roi.height == 35
+
+
+# ---------------------------------------------------------------------------
+# Lines 221–228: _update_bbox_from_points() — empty-points no-op and normal update
+# ---------------------------------------------------------------------------
+
+
+def test_update_bbox_from_points_is_noop_when_points_empty():
+    """_update_bbox_from_points does not change bbox when points list is empty."""
+    roi = ROI(
+        x=5, y=5, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10)],
+    )
+    roi.points = []
+    roi._update_bbox_from_points()
+    assert roi.x == 5
+    assert roi.width == 10
+
+
+def test_update_bbox_from_points_recomputes_after_vertex_edit():
+    """_update_bbox_from_points correctly recomputes bbox when a vertex is moved."""
+    roi = ROI(
+        x=0, y=0, width=11, height=11,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    roi.points[3] = (0, 20)  # extend y range
+    roi._update_bbox_from_points()
+    # max y=20, min y=0 → height = 20 - 0 + 1 = 21
+    assert roi.height == 21
+    assert roi.y == 0
+
+
+# ---------------------------------------------------------------------------
+# Lines 230–238: delete_vertex()
+# ---------------------------------------------------------------------------
+
+
+def test_delete_vertex_removes_vertex_when_more_than_3():
+    """delete_vertex removes the indexed vertex and returns True for a 4-vertex polygon."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    result = roi.delete_vertex(1)
+    assert result is True
+    assert len(roi.points) == 3
+    assert (10, 0) not in roi.points
+
+
+def test_delete_vertex_bbox_updated_after_deletion():
+    """delete_vertex updates the bounding box after removing a vertex."""
+    roi = ROI(
+        x=0, y=0, width=21, height=21,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (20, 0), (20, 20), (0, 10), (0, 20)],
+    )
+    roi.delete_vertex(4)  # remove (0, 20)
+    # remaining max-y is now 20 (from vertex 2), unchanged, but test bbox recalculated
+    assert roi.width >= 1 and roi.height >= 1
+
+
+def test_delete_vertex_refuses_when_exactly_3_vertices():
+    """delete_vertex returns False without modifying the polygon when it has only 3 vertices."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (5, 10)],
+    )
+    assert roi.delete_vertex(0) is False
+    assert len(roi.points) == 3
+
+
+def test_delete_vertex_refuses_for_ellipse_roi():
+    """delete_vertex returns False immediately for a non-polygon ROI."""
+    roi = ROI(x=0, y=0, width=10, height=10, shape=ROIShape.ELLIPSE)
+    assert roi.delete_vertex(0) is False
+
+
+def test_delete_vertex_refuses_out_of_range_index():
+    """delete_vertex returns False when the index is out of range."""
+    roi = ROI(
+        x=0, y=0, width=10, height=10,
+        shape=ROIShape.POLYGON,
+        points=[(0, 0), (10, 0), (10, 10), (0, 10)],
+    )
+    assert roi.delete_vertex(99) is False
+    assert len(roi.points) == 4
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: create_mask produces correct shape across image/ROI sizes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("img_w,img_h,roi_x,roi_y", [
+    (10, 10, 0, 0),
+    (50, 50, 20, 20),
+    (100, 80, 40, 30),
+])
+def test_create_mask_polygon_shape_matches_image_dimensions(img_w, img_h, roi_x, roi_y):
+    """create_mask for a polygon returns a uint8 mask with (img_h, img_w) shape."""
+    pts = [(roi_x, roi_y), (roi_x + 4, roi_y), (roi_x + 2, roi_y + 4)]
+    roi = ROI(x=roi_x, y=roi_y, width=5, height=5, shape=ROIShape.POLYGON, points=pts)
+    mask = roi.create_mask(img_w, img_h)
+    assert mask.shape == (img_h, img_w)
+    assert mask.dtype == np.uint8

--- a/tests/test_roi_geometry.py
+++ b/tests/test_roi_geometry.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from core.roi import ROI, ROIHandle, ROIShape
 
 
@@ -57,7 +58,10 @@ def test_roi_contains_point_and_create_mask_work_for_both_shapes():
 def test_get_center_polygon_returns_mean_of_vertices():
     """Polygon get_center returns the arithmetic mean of all vertex coordinates."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (4, 0), (4, 4), (0, 4)],
     )
@@ -69,7 +73,10 @@ def test_get_center_polygon_returns_mean_of_vertices():
 def test_get_center_polygon_triangle_centroid():
     """Triangle centroid is computed as the mean of its three vertices."""
     roi = ROI(
-        x=0, y=0, width=6, height=6,
+        x=0,
+        y=0,
+        width=6,
+        height=6,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (6, 0), (3, 6)],
     )
@@ -103,7 +110,10 @@ def test_contains_point_zero_height_ellipse_returns_false():
 def test_get_handle_at_point_polygon_vertex_hit_returns_vertex_tuple():
     """A point on a polygon vertex returns (ROIHandle.VERTEX, index)."""
     roi = ROI(
-        x=0, y=0, width=20, height=20,
+        x=0,
+        y=0,
+        width=20,
+        height=20,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (20, 0), (20, 20), (0, 20)],
     )
@@ -114,7 +124,10 @@ def test_get_handle_at_point_polygon_vertex_hit_returns_vertex_tuple():
 def test_get_handle_at_point_polygon_second_vertex_hit():
     """A point on the second polygon vertex returns (VERTEX, 1)."""
     roi = ROI(
-        x=0, y=0, width=20, height=20,
+        x=0,
+        y=0,
+        width=20,
+        height=20,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (20, 0), (20, 20), (0, 20)],
     )
@@ -125,7 +138,10 @@ def test_get_handle_at_point_polygon_second_vertex_hit():
 def test_get_handle_at_point_polygon_inside_returns_move():
     """A point inside the polygon (not on a vertex) returns MOVE."""
     roi = ROI(
-        x=0, y=0, width=40, height=40,
+        x=0,
+        y=0,
+        width=40,
+        height=40,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (40, 0), (40, 40), (0, 40)],
     )
@@ -136,7 +152,10 @@ def test_get_handle_at_point_polygon_inside_returns_move():
 def test_get_handle_at_point_polygon_outside_returns_none():
     """A point outside the polygon (and not on a vertex) returns NONE."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -188,7 +207,10 @@ def test_get_handle_at_point_ellipse_far_outside_returns_none():
 def test_adjust_with_handle_polygon_move_shifts_all_vertices():
     """MOVE handle shifts every polygon vertex by (dx, dy)."""
     roi = ROI(
-        x=5, y=5, width=10, height=10,
+        x=5,
+        y=5,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(5, 5), (15, 5), (15, 15), (5, 15)],
     )
@@ -202,7 +224,10 @@ def test_adjust_with_handle_polygon_move_shifts_all_vertices():
 def test_adjust_with_handle_polygon_move_clamps_to_image_bounds():
     """MOVE handle clamps all polygon vertices so they stay within image bounds."""
     roi = ROI(
-        x=0, y=0, width=5, height=5,
+        x=0,
+        y=0,
+        width=5,
+        height=5,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (5, 0), (5, 5), (0, 5)],
     )
@@ -215,7 +240,10 @@ def test_adjust_with_handle_polygon_move_clamps_to_image_bounds():
 def test_adjust_with_handle_polygon_vertex_moves_single_vertex():
     """VERTEX handle with vertex_index moves only the specified vertex."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -227,7 +255,10 @@ def test_adjust_with_handle_polygon_vertex_moves_single_vertex():
 def test_adjust_with_handle_polygon_tuple_handle_unpacked_correctly():
     """Tuple (VERTEX, index) handle is unpacked and moves the correct vertex."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -239,7 +270,10 @@ def test_adjust_with_handle_polygon_tuple_handle_unpacked_correctly():
 def test_adjust_with_handle_polygon_vertex_clamps_to_bounds():
     """VERTEX handle clamps the moved vertex to [0, image_dim-1]."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -313,7 +347,10 @@ def test_adjust_with_handle_ellipse_bottom_right_resizes():
 def test_update_bbox_from_points_is_noop_when_points_empty():
     """_update_bbox_from_points does not change bbox when points list is empty."""
     roi = ROI(
-        x=5, y=5, width=10, height=10,
+        x=5,
+        y=5,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10)],
     )
@@ -326,7 +363,10 @@ def test_update_bbox_from_points_is_noop_when_points_empty():
 def test_update_bbox_from_points_recomputes_after_vertex_edit():
     """_update_bbox_from_points correctly recomputes bbox when a vertex is moved."""
     roi = ROI(
-        x=0, y=0, width=11, height=11,
+        x=0,
+        y=0,
+        width=11,
+        height=11,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -345,7 +385,10 @@ def test_update_bbox_from_points_recomputes_after_vertex_edit():
 def test_delete_vertex_removes_vertex_when_more_than_3():
     """delete_vertex removes the indexed vertex and returns True for a 4-vertex polygon."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -358,7 +401,10 @@ def test_delete_vertex_removes_vertex_when_more_than_3():
 def test_delete_vertex_bbox_updated_after_deletion():
     """delete_vertex updates the bounding box after removing a vertex."""
     roi = ROI(
-        x=0, y=0, width=21, height=21,
+        x=0,
+        y=0,
+        width=21,
+        height=21,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (20, 0), (20, 20), (0, 10), (0, 20)],
     )
@@ -370,7 +416,10 @@ def test_delete_vertex_bbox_updated_after_deletion():
 def test_delete_vertex_refuses_when_exactly_3_vertices():
     """delete_vertex returns False without modifying the polygon when it has only 3 vertices."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (5, 10)],
     )
@@ -387,7 +436,10 @@ def test_delete_vertex_refuses_for_ellipse_roi():
 def test_delete_vertex_refuses_out_of_range_index():
     """delete_vertex returns False when the index is out of range."""
     roi = ROI(
-        x=0, y=0, width=10, height=10,
+        x=0,
+        y=0,
+        width=10,
+        height=10,
         shape=ROIShape.POLYGON,
         points=[(0, 0), (10, 0), (10, 10), (0, 10)],
     )
@@ -400,11 +452,14 @@ def test_delete_vertex_refuses_out_of_range_index():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("img_w,img_h,roi_x,roi_y", [
-    (10, 10, 0, 0),
-    (50, 50, 20, 20),
-    (100, 80, 40, 30),
-])
+@pytest.mark.parametrize(
+    "img_w,img_h,roi_x,roi_y",
+    [
+        (10, 10, 0, 0),
+        (50, 50, 20, 20),
+        (100, 80, 40, 30),
+    ],
+)
 def test_create_mask_polygon_shape_matches_image_dimensions(img_w, img_h, roi_x, roi_y):
     """create_mask for a polygon returns a uint8 mask with (img_h, img_w) shape."""
     pts = [(roi_x, roi_y), (roi_x + 4, roi_y), (roi_x + 2, roi_y + 4)]

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,8 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11'" },
+    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 
 [[package]]
@@ -618,7 +619,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
@@ -730,6 +731,7 @@ dev = [
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-env" },
 ]
 
 [package.metadata]
@@ -745,6 +747,7 @@ requires-dist = [
     { name = "pystackreg", specifier = ">=0.2.8" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
+    { name = "pytest-env", marker = "extra == 'test'", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "scikit-image", specifier = ">=0.21.0" },
     { name = "scipy", specifier = ">=1.11.0" },
@@ -1289,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1298,11 +1301,11 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -1320,6 +1323,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+    { name = "tomli", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/69/4db1c30625af0621df8dbe73797b38b6d1b04e15d021dd5d26a6d297f78c/pytest_env-1.6.0.tar.gz", hash = "sha256:ac02d6fba16af54d61e311dd70a3c61024a4e966881ea844affc3c8f0bf207d3", size = 16163, upload-time = "2026-03-12T22:39:43.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl", hash = "sha256:1e7f8a62215e5885835daaed694de8657c908505b964ec8097a7ce77b403d9a3", size = 10400, upload-time = "2026-03-12T22:39:41.887Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1329,6 +1346,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1682,6 +1708,12 @@ wheels = [
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236, upload-time = "2025-10-08T22:01:00.137Z" },
@@ -1725,6 +1757,66 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for image→QImage conversion (grayscale/RGB/RGBA formats, dtypes, strides, error cases) and expanded ROI geometry and plotting-widget coverage.
* **Test Configuration**
  * Early Qt initialization and Matplotlib set to a non-interactive backend to stabilize test runs.
* **Behavior Changes**
  * Polygon cropping now applies a single rasterized mask across frames for correctness and performance, affecting masked pixels in crops.
* **Chores**
  * Updated test dependencies and expanded .gitignore for coverage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->