### PR TITLE
Added diaplay effect do not change the outcome

### DIFF
--- a/src/ui/workflow.py
+++ b/src/ui/workflow.py
@@ -60,7 +60,7 @@ STEP_DEFINITIONS: Dict[WorkflowStep, StepMeta] = {
         description=(
             "Use the Display options panel to adjust exposure and "
             "contrast until neurons and background are clearly separated. "
-            "Display setting do not effect the underlying data, just how it's visualized in the viewer."
+            "Display settings do not affect the underlying data, only how it is visualized in the viewer."
         ),
     ),
     WorkflowStep.ALIGN_IMAGES: StepMeta(

--- a/src/ui/workflow.py
+++ b/src/ui/workflow.py
@@ -59,7 +59,8 @@ STEP_DEFINITIONS: Dict[WorkflowStep, StepMeta] = {
         tooltip=("Adjust exposure and contrast so structures of interest are clearly visible."),
         description=(
             "Use the Display options panel to adjust exposure and "
-            "contrast until neurons and background are clearly separated."
+            "contrast until neurons and background are clearly separated. "
+            "Display setting do not effect the underlying data, just how it's visualized in the viewer."
         ),
     ),
     WorkflowStep.ALIGN_IMAGES: StepMeta(


### PR DESCRIPTION
The display settings are strictly visual and have no impact on the underlying data, calculations, or graph outputs.
resolves: #119
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording in the image-editing step to state that display settings only change visualization in the viewer and do not modify the underlying data.
  * Minor copy update to improve clarity for users when adjusting viewer display options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->