### PR TITLE
Add image culling interface and update related workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get install -y libegl1 libxkbcommon0 libdbus-1-3 libxcb-cursor0
 
       - name: Run tests
-        run: uv run pytest tests/ -v --cov=src --cov-branch --cov-report=xml
+        run: uv run pytest tests/ -v
         env:
           QT_QPA_PLATFORM: offscreen
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+  # Carry forward flags so partial CI runs don't wipe coverage data.
+  round: nearest
+  precision: 2
+
+ignore:
+  - "src/__init__.py"
+  - "src/main.py"
+  - "tests/**"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,25 @@ select = ["F", "E", "I"]
 testpaths = ["tests"]
 pythonpath = ["src"]
 env = ["MPLBACKEND=Agg"]
+addopts = "--cov=src --cov-branch --cov-report=term-missing:skip-covered --cov-report=xml"
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+omit = [
+    "src/__init__.py",
+    "src/main.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@overload",
+]
+show_missing = true
+skip_covered = true
+fail_under = 0
 

--- a/src/ui/image_viewer.py
+++ b/src/ui/image_viewer.py
@@ -64,6 +64,7 @@ class ImageViewer(QWidget):
 
         # Frame culling state
         self._excluded_frames: Set[int] = set()
+        self._filter_excluded: bool = False
 
         # Dual ROI state
         self.current_rois: Dict[str, Optional[ROI]] = {"roi_1": None, "roi_2": None}
@@ -269,14 +270,14 @@ class ImageViewer(QWidget):
 
     def set_stack(self, files) -> None:
         self.handler.load_image_stack(files)
-        count = self.handler.get_image_count()
-        self.slider.setRange(0, max(0, count - 1))
-        self.index = 0
-        self._update_frame_index_label(count)
+        vis = self._visible_indices
+        self.slider.setRange(0, max(0, len(vis) - 1))
+        self.index = vis[0] if vis else 0
+        self._update_frame_index_label(len(vis))
         self._show_current()
 
         # Hide upload button when images are loaded
-        if count > 0:
+        if len(vis) > 0:
             self.upload_btn.hide()
 
         # Determine directory path and emit
@@ -299,6 +300,7 @@ class ImageViewer(QWidget):
         self.index = 0
         self.cache = _LRUCache(20)
         self._excluded_frames = set()
+        self._filter_excluded = False
         self.current_rois = {"roi_1": None, "roi_2": None}
         self.active_roi_key = "roi_1"
         self._populate_roi_selector()
@@ -415,7 +417,8 @@ class ImageViewer(QWidget):
         return unit_8
 
     def _show_current(self) -> None:
-        count = self.handler.get_image_count()
+        vis = self._visible_indices
+        count = len(vis)
         if count == 0:
             self.image_label.clear()
             self.frame_index_label.setText("— / —")
@@ -512,8 +515,9 @@ class ImageViewer(QWidget):
 
         self.image_label.setPixmap(scaled_pix)
         current_path = Path(self.handler.files[self.index])
+        display_pos = vis.index(self.index) + 1 if self.index in vis else self.index + 1
         self._update_frame_index_label(count)
-        self.filename_label.setText(f"{self.index + 1}/{count}: \n{current_path.name}")
+        self.filename_label.setText(f"{display_pos}/{count}: \n{current_path.name}")
 
         self._refresh_cull_button()
 
@@ -560,23 +564,35 @@ class ImageViewer(QWidget):
             self.set_stack(files)
 
     def prev_image(self) -> None:
-        if self.index > 0:
-            self.index -= 1
+        vis = self._visible_indices
+        if not vis:
+            return
+        pos = vis.index(self.index) if self.index in vis else 0
+        if pos > 0:
+            self.index = vis[pos - 1]
             self.slider.blockSignals(True)
-            self.slider.setValue(self.index)
+            self.slider.setValue(pos - 1)
             self.slider.blockSignals(False)
             self._show_current()
 
     def next_image(self) -> None:
-        if self.index < max(0, self.handler.get_image_count() - 1):
-            self.index += 1
+        vis = self._visible_indices
+        if not vis:
+            return
+        pos = vis.index(self.index) if self.index in vis else 0
+        if pos < len(vis) - 1:
+            self.index = vis[pos + 1]
             self.slider.blockSignals(True)
-            self.slider.setValue(self.index)
+            self.slider.setValue(pos + 1)
             self.slider.blockSignals(False)
             self._show_current()
 
     def _on_slider(self, value: int) -> None:
-        self.index = value
+        vis = self._visible_indices
+        if vis and 0 <= value < len(vis):
+            self.index = vis[value]
+        else:
+            self.index = value
         self._show_current()
 
     def _update_frame_index_label(self, count: int) -> None:
@@ -704,6 +720,31 @@ class ImageViewer(QWidget):
     # ------------------------------------------------------------------
     # Frame culling helpers
     # ------------------------------------------------------------------
+
+    @property
+    def _visible_indices(self) -> list:
+        """Raw file indices the viewer should navigate through."""
+        total = self.handler.get_image_count()
+        if not self._filter_excluded or not self._excluded_frames:
+            return list(range(total))
+        return [i for i in range(total) if i not in self._excluded_frames]
+
+    def set_filter_excluded(self, enabled: bool) -> None:
+        """Toggle whether excluded frames are hidden from navigation."""
+        if self._filter_excluded == enabled:
+            return
+        self._filter_excluded = enabled
+        vis = self._visible_indices
+        if not vis:
+            return
+        self.slider.blockSignals(True)
+        self.slider.setRange(0, max(0, len(vis) - 1))
+        # Snap current index to the nearest visible frame
+        if self.index not in vis:
+            self.index = vis[0]
+        self.slider.setValue(vis.index(self.index))
+        self.slider.blockSignals(False)
+        self._show_current()
 
     def get_excluded_frames(self) -> Set[int]:
         return set(self._excluded_frames)

--- a/src/ui/image_viewer.py
+++ b/src/ui/image_viewer.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 import cv2
 import numpy as np
 from PySide6.QtCore import QPointF, Qt, Signal
-from PySide6.QtGui import QColor, QIcon, QPainter, QPen, QPixmap, QPolygonF
+from PySide6.QtGui import QColor, QFont, QIcon, QPainter, QPen, QPixmap, QPolygonF
 from PySide6.QtWidgets import (
     QComboBox,
     QGroupBox,
@@ -54,12 +54,16 @@ class ImageViewer(QWidget):
     roiChanged = Signal(str, object)  # Emits (roi_key, ROI object) when adjusted
     roiDeleted = Signal(str)  # Emits roi_key when an ROI is deleted
     displaySettingsChanged = Signal(int, int)  # Emits (exposure, contrast) when display settings change
+    frameCullingChanged = Signal(object)  # Emits set of excluded frame indices
 
     def __init__(self, handler: ImageStackHandler) -> None:
         super().__init__()
         self.handler = handler
         self.index = 0
         self.cache = _LRUCache(20)
+
+        # Frame culling state
+        self._excluded_frames: Set[int] = set()
 
         # Dual ROI state
         self.current_rois: Dict[str, Optional[ROI]] = {"roi_1": None, "roi_2": None}
@@ -194,6 +198,22 @@ class ImageViewer(QWidget):
 
         self.display_controls_panel.setVisible(False)
 
+        # Frame culling panel (shown only during Cull Frames workflow step)
+        self.cull_controls_panel = QWidget()
+        cull_panel_layout = QVBoxLayout(self.cull_controls_panel)
+        cull_panel_layout.setContentsMargins(0, 0, 0, 0)
+        cull_panel_layout.setSpacing(4)
+
+        self._cull_toggle_btn = QPushButton("Exclude Frame")
+        self._cull_toggle_btn.setCheckable(True)
+        self._cull_toggle_btn.clicked.connect(self._on_cull_toggle)
+        cull_panel_layout.addWidget(self._cull_toggle_btn)
+
+        self._cull_count_label = QLabel("0 frames excluded")
+        cull_panel_layout.addWidget(self._cull_count_label)
+
+        self.cull_controls_panel.setVisible(False)
+
         # Frame row: prev, slider, index, next — all on one line
         frame_row = QHBoxLayout()
         frame_row.addWidget(self.prev_btn)
@@ -206,6 +226,7 @@ class ImageViewer(QWidget):
         layout.addWidget(self.roi_controls_panel)
         layout.addLayout(frame_row)
         layout.addWidget(self.display_controls_panel)
+        layout.addWidget(self.cull_controls_panel)
         self.filename_label.setMaximumHeight(50)
         layout.addWidget(self.filename_label, 0)
         self._update_adjustment_labels()
@@ -277,6 +298,7 @@ class ImageViewer(QWidget):
         self.handler.files = []
         self.index = 0
         self.cache = _LRUCache(20)
+        self._excluded_frames = set()
         self.current_rois = {"roi_1": None, "roi_2": None}
         self.active_roi_key = "roi_1"
         self._populate_roi_selector()
@@ -285,6 +307,7 @@ class ImageViewer(QWidget):
         self.frame_index_label.setText("— / —")
         self.slider.setRange(0, 0)
         self._update_roi_button_text()
+        self._refresh_cull_button()
         self.prev_btn.setEnabled(True)
         self.next_btn.setEnabled(True)
         self.slider.setEnabled(True)
@@ -474,10 +497,25 @@ class ImageViewer(QWidget):
                 painter.drawEllipse(x_scaled, y_scaled, w_scaled, h_scaled)
             painter.end()
 
+        # Draw "EXCLUDED" overlay when current frame is culled
+        if self.index in self._excluded_frames:
+            painter = QPainter(scaled_pix)
+            overlay_color = QColor(180, 40, 40, 100)
+            painter.fillRect(scaled_pix.rect(), overlay_color)
+            painter.setPen(QPen(QColor(255, 60, 60, 220)))
+            font = QFont()
+            font.setPixelSize(max(20, scaled_pix.height() // 8))
+            font.setBold(True)
+            painter.setFont(font)
+            painter.drawText(scaled_pix.rect(), Qt.AlignCenter, "EXCLUDED")
+            painter.end()
+
         self.image_label.setPixmap(scaled_pix)
         current_path = Path(self.handler.files[self.index])
         self._update_frame_index_label(count)
         self.filename_label.setText(f"{self.index + 1}/{count}: \n{current_path.name}")
+
+        self._refresh_cull_button()
 
     def resizeEvent(self, event) -> None:  # noqa: N802
         # ROI FIX: Redraw on resize so ROI scale updates correctly
@@ -662,3 +700,35 @@ class ImageViewer(QWidget):
         self.current_rois[key] = roi
         self._update_roi_button_text()
         self._show_current()
+
+    # ------------------------------------------------------------------
+    # Frame culling helpers
+    # ------------------------------------------------------------------
+
+    def get_excluded_frames(self) -> Set[int]:
+        return set(self._excluded_frames)
+
+    def set_excluded_frames(self, indices: Set[int]) -> None:
+        """Restore excluded frames (e.g. from saved experiment), without emitting."""
+        self._excluded_frames = set(indices)
+        self._refresh_cull_button()
+        self._show_current()
+
+    def _on_cull_toggle(self) -> None:
+        if self.index in self._excluded_frames:
+            self._excluded_frames.discard(self.index)
+        else:
+            self._excluded_frames.add(self.index)
+        self._refresh_cull_button()
+        self._show_current()
+        self.frameCullingChanged.emit(set(self._excluded_frames))
+
+    def _refresh_cull_button(self) -> None:
+        is_excluded = self.index in self._excluded_frames
+        self._cull_toggle_btn.blockSignals(True)
+        self._cull_toggle_btn.setChecked(is_excluded)
+        self._cull_toggle_btn.blockSignals(False)
+        self._cull_toggle_btn.setText("Include Frame" if is_excluded else "Exclude Frame")
+
+        n = len(self._excluded_frames)
+        self._cull_count_label.setText(f"{n} frame{'s' if n != 1 else ''} excluded")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1216,6 +1216,17 @@ class MainWindow(QMainWindow):
         self.experiment.settings["culling"]["excluded_frames"] = sorted(excluded)
         self.stack_handler.set_excluded_frames(excluded)
 
+        # Keep neuron detection input in sync with the included-only stack.
+        # Detection operates on the frame_data provided to the widget; if culling
+        # changes after load, we must refresh it.
+        try:
+            if hasattr(self, "analysis"):
+                detection_widget = self.analysis.get_neuron_detection_widget()
+                detection_widget.set_frame_data(self.stack_handler.get_all_frames_as_array())
+        except Exception:
+            # Some tests use lightweight/mocked panels; ignore refresh failures.
+            pass
+
         total = self.stack_handler.get_total_frame_count()
         all_excluded = total > 0 and len(excluded) >= total
 
@@ -1253,6 +1264,14 @@ class MainWindow(QMainWindow):
             logger.warning("Skipped %d malformed excluded-frame entries", skipped)
         self.stack_handler.set_excluded_frames(excluded)
         self.viewer.set_excluded_frames(excluded)
+
+        # Ensure detection uses the included-only stack after restoring culling.
+        try:
+            if hasattr(self, "analysis"):
+                detection_widget = self.analysis.get_neuron_detection_widget()
+                detection_widget.set_frame_data(self.stack_handler.get_all_frames_as_array())
+        except Exception:
+            pass
 
     def _flush_pending_display_settings(self) -> None:
         """

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -283,7 +283,9 @@ class MainWindow(QMainWindow):
                     panel.setVisible(show_cull)
                 # After the cull step, hide excluded frames from navigation
                 cull_index = STEP_DEFINITIONS[WorkflowStep.CULL_FRAMES].index
-                self.viewer.set_filter_excluded(current_index > cull_index)
+                _set_filter = getattr(self.viewer, "set_filter_excluded", None)
+                if callable(_set_filter):
+                    _set_filter(current_index > cull_index)
 
             # Step 4: Align Images
             enable_align = current == WorkflowStep.ALIGN_IMAGES
@@ -578,7 +580,9 @@ class MainWindow(QMainWindow):
         self.viewer.displaySettingsChanged.connect(self._on_display_settings_changed)
 
         # Connect frame culling changes
-        self.viewer.frameCullingChanged.connect(self._on_frame_culling_changed)
+        _culling_signal = getattr(self.viewer, "frameCullingChanged", None)
+        if _culling_signal is not None:
+            _culling_signal.connect(self._on_frame_culling_changed)
 
         # Create data analyzer
         self.data_analyzer = DataAnalyzer(self.experiment)
@@ -1238,7 +1242,15 @@ class MainWindow(QMainWindow):
         """Restore excluded frames from experiment settings into viewer and handler."""
         culling = self.experiment.settings.get("culling") or {}
         excluded_list = culling.get("excluded_frames", [])
-        excluded = set(int(i) for i in excluded_list)
+        excluded: set[int] = set()
+        skipped = 0
+        for item in excluded_list:
+            try:
+                excluded.add(int(item))
+            except (ValueError, TypeError):
+                skipped += 1
+        if skipped:
+            logger.warning("Skipped %d malformed excluded-frame entries", skipped)
         self.stack_handler.set_excluded_frames(excluded)
         self.viewer.set_excluded_frames(excluded)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -184,6 +184,9 @@ class MainWindow(QMainWindow):
                 panel = getattr(self.viewer, "cull_controls_panel", None)
                 if panel is not None:
                     panel.setVisible(show_cull)
+                # After the cull step, hide excluded frames from navigation
+                cull_index = STEP_DEFINITIONS[WorkflowStep.CULL_FRAMES].index
+                self.viewer.set_filter_excluded(current_index > cull_index)
 
             # Step 4: Align Images
             enable_align = current == WorkflowStep.ALIGN_IMAGES

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1154,12 +1154,12 @@ class MainWindow(QMainWindow):
             from PIL import Image
 
             output_path = Path(output_dir)
-            original_files = self.stack_handler.files
+            included_files = self.stack_handler.get_included_files()
 
             for i, cropped_frame in enumerate(cropped_stack):
-                # Generate output filename
-                if i < len(original_files):
-                    original_name = Path(original_files[i]).stem
+                # Generate output filename from the matching source file
+                if i < len(included_files):
+                    original_name = Path(included_files[i]).stem
                     output_file = output_path / f"{original_name}_cropped.tif"
                 else:
                     output_file = output_path / f"frame_{i:04d}_cropped.tif"
@@ -1452,10 +1452,11 @@ class MainWindow(QMainWindow):
 
         # Save aligned images (raw, without exposure/contrast adjustments)
         # Users can adjust exposure/contrast in the viewer after loading
+        included_files = self.stack_handler.get_included_files()
         for i, aligned_frame in enumerate(aligned_stack_uint16):
-            # Generate output filename
-            if i < len(self.stack_handler.files):
-                original_name = Path(self.stack_handler.files[i]).stem
+            # Generate output filename from the matching source file
+            if i < len(included_files):
+                original_name = Path(included_files[i]).stem
                 output_file = output_path / f"{original_name}_aligned.tif"
             else:
                 output_file = output_path / f"frame_{i:04d}_aligned.tif"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -178,19 +178,26 @@ class MainWindow(QMainWindow):
                 if panel is not None:
                     panel.setVisible(show_edit)
 
-            # Step 3: Align Images
+            # Step 3: Cull Frames — show/hide cull controls panel
+            show_cull = current == WorkflowStep.CULL_FRAMES
+            if hasattr(self, "viewer"):
+                panel = getattr(self.viewer, "cull_controls_panel", None)
+                if panel is not None:
+                    panel.setVisible(show_cull)
+
+            # Step 4: Align Images
             enable_align = current == WorkflowStep.ALIGN_IMAGES
             if self._action_align_images is not None:
                 self._action_align_images.setEnabled(enable_align)
 
-            # Step 4: Select ROI — show/hide entire ROI controls panel
+            # Step 5: Select ROI — show/hide entire ROI controls panel
             show_roi = current == WorkflowStep.SELECT_ROI
             if hasattr(self, "viewer"):
                 panel = getattr(self.viewer, "roi_controls_panel", None)
                 if panel is not None:
                     panel.setVisible(show_roi)
 
-            # Step 5: Detect Neurons
+            # Step 6: Detect Neurons
             enable_detect = current == WorkflowStep.DETECT_NEURONS
             if hasattr(self, "analysis"):
                 try:
@@ -465,6 +472,9 @@ class MainWindow(QMainWindow):
         # Connect display settings changes to debounced saving
         self.viewer.displaySettingsChanged.connect(self._on_display_settings_changed)
 
+        # Connect frame culling changes
+        self.viewer.frameCullingChanged.connect(self._on_frame_culling_changed)
+
         # Create data analyzer
         self.data_analyzer = DataAnalyzer(self.experiment)
 
@@ -583,6 +593,9 @@ class MainWindow(QMainWindow):
                             QApplication.processEvents()
                             self.viewer.set_stack(p)
 
+                        # Restore culling state
+                        self._restore_culling_state()
+
                         # Load both ROIs from experiment.rois
                         has_any_roi = any(self.experiment.rois.get(k) for k in ("roi_1", "roi_2"))
                         if has_any_roi:
@@ -699,6 +712,9 @@ class MainWindow(QMainWindow):
 
         # Mark first workflow step complete once a stack is available
         self.workflow_manager.complete_step_if_current(WorkflowStep.LOAD_IMAGES)
+
+        # Cull step is always ready (zero exclusions is a valid choice)
+        self.workflow_manager.mark_step_ready(WorkflowStep.CULL_FRAMES)
 
     def _ensure_detection_data_saved(self) -> None:
         """
@@ -1013,6 +1029,43 @@ class MainWindow(QMainWindow):
         self._display_settings_timer.start(500)
         if self.workflow_manager.current_step == WorkflowStep.EDIT_IMAGES:
             self.workflow_manager.mark_step_ready(WorkflowStep.EDIT_IMAGES)
+
+    def _on_frame_culling_changed(self, excluded: set) -> None:
+        """Persist excluded frames to experiment and sync to the stack handler."""
+        if "culling" not in self.experiment.settings:
+            self.experiment.settings["culling"] = {}
+        self.experiment.settings["culling"]["excluded_frames"] = sorted(excluded)
+        self.stack_handler.set_excluded_frames(excluded)
+
+        total = self.stack_handler.get_total_frame_count()
+        all_excluded = total > 0 and len(excluded) >= total
+
+        if all_excluded:
+            # Cannot advance with zero included frames — remove readiness
+            self.workflow_manager._ready_steps.discard(WorkflowStep.CULL_FRAMES)
+            self.workflow_manager.state_changed.emit()
+        else:
+            self.workflow_manager.mark_step_ready(WorkflowStep.CULL_FRAMES)
+
+        # If culling changed after downstream steps completed, invalidate them
+        if WorkflowStep.CULL_FRAMES in self.workflow_manager.completed_steps:
+            self.workflow_manager.reset_from_step(WorkflowStep.CULL_FRAMES)
+            if not all_excluded:
+                self.workflow_manager.mark_step_ready(WorkflowStep.CULL_FRAMES)
+
+        if self.current_experiment_path:
+            try:
+                self.manager.save_experiment(self.experiment, self.current_experiment_path)
+            except Exception:
+                pass
+
+    def _restore_culling_state(self) -> None:
+        """Restore excluded frames from experiment settings into viewer and handler."""
+        culling = self.experiment.settings.get("culling") or {}
+        excluded_list = culling.get("excluded_frames", [])
+        excluded = set(int(i) for i in excluded_list)
+        self.stack_handler.set_excluded_frames(excluded)
+        self.viewer.set_excluded_frames(excluded)
 
     def _flush_pending_display_settings(self) -> None:
         """

--- a/src/ui/workflow.py
+++ b/src/ui/workflow.py
@@ -22,6 +22,7 @@ from core.experiment_manager import Experiment
 class WorkflowStep(Enum):
     LOAD_IMAGES = auto()
     EDIT_IMAGES = auto()
+    CULL_FRAMES = auto()
     ALIGN_IMAGES = auto()
     SELECT_ROI = auto()
     DETECT_NEURONS = auto()
@@ -63,14 +64,24 @@ STEP_DEFINITIONS: Dict[WorkflowStep, StepMeta] = {
             "Display settings do not affect the underlying data, only how it is visualized in the viewer."
         ),
     ),
-    WorkflowStep.ALIGN_IMAGES: StepMeta(
+    WorkflowStep.CULL_FRAMES: StepMeta(
         index=3,
+        short_label="Cull Frames",
+        tooltip="Browse frames and exclude any that should be skipped in downstream analysis.",
+        description=(
+            "Step through the image stack and mark individual frames for exclusion. "
+            "Excluded frames will be skipped during alignment, detection, and analysis. "
+            "You may proceed without excluding any frames."
+        ),
+    ),
+    WorkflowStep.ALIGN_IMAGES: StepMeta(
+        index=4,
         short_label="Align Images",
         tooltip="Align frames in the stack using PyStackReg to correct motion.",
         description=("Run image alignment from the Tools → Align Images menu to correct for motion across the stack."),
     ),
     WorkflowStep.SELECT_ROI: StepMeta(
-        index=4,
+        index=5,
         short_label="Select ROI",
         tooltip="Define the Region of Interest (ROI) where neurons will be detected.",
         description=(
@@ -80,14 +91,14 @@ STEP_DEFINITIONS: Dict[WorkflowStep, StepMeta] = {
         ),
     ),
     WorkflowStep.DETECT_NEURONS: StepMeta(
-        index=5,
+        index=6,
         short_label="Detect Neurons",
         tooltip="Run automated neuron detection inside the ROI.",
         description="Configure detection parameters, then run automated neuron detection. "
         "Results will be overlaid on the image and used for downstream analysis.",
     ),
     WorkflowStep.ANALYZE_GRAPHS: StepMeta(
-        index=6,
+        index=7,
         short_label="Analysis",
         tooltip="Inspect ROI intensity and neuron trajectory graphs.",
         description="Review ROI intensity traces and neuron trajectories in the analysis tabs. "
@@ -262,6 +273,7 @@ class WorkflowManager(QObject):
         if has_stack:
             self.completed_steps.add(WorkflowStep.LOAD_IMAGES)
             self.completed_steps.add(WorkflowStep.EDIT_IMAGES)
+            self.completed_steps.add(WorkflowStep.CULL_FRAMES)
 
         if has_roi:
             self.completed_steps.add(WorkflowStep.SELECT_ROI)

--- a/src/utils/file_handler.py
+++ b/src/utils/file_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 
 import numpy as np
 from PIL import Image
@@ -13,6 +13,17 @@ class ImageStackHandler:
     def __init__(self) -> None:
         self.files: List[str] = []
         self._experiment: Optional[Experiment] = None
+        self._excluded_frames: Set[int] = set()
+
+    def set_excluded_frames(self, indices: Set[int]) -> None:
+        self._excluded_frames = set(indices)
+
+    def get_excluded_frames(self) -> Set[int]:
+        return set(self._excluded_frames)
+
+    def get_total_frame_count(self) -> int:
+        """Return total number of files regardless of exclusions."""
+        return len(self.files)
 
     def load_image_stack(self, directory_or_files) -> List[str]:
         paths: List[str] = []
@@ -28,6 +39,7 @@ class ImageStackHandler:
                     if p.is_file() and p.suffix.lower() in (".tif", ".tiff"):
                         paths.append(str(p))
         self.files = paths
+        self._excluded_frames = set()
         return self.files
 
     def validate_tif_files(self, file_paths: List[str]) -> bool:
@@ -57,15 +69,17 @@ class ImageStackHandler:
             return np.asarray(img)
 
     def get_all_frames_as_array(self) -> Optional[np.ndarray]:
-        """Load all frames as a 3D numpy array (frames, height, width).
-        Reuses approach from Jupyter notebook.
+        """Load all non-excluded frames as a 3D numpy array (frames, height, width).
         Preserves original image dtype to avoid precision loss (consistent with get_image_at_index).
         """
         if not self.files:
             return None
 
+        included_files = [p for i, p in enumerate(self.files) if i not in self._excluded_frames]
+        if not included_files:
+            return None
+
         def _load_one(file_path: str) -> np.ndarray:
-            # NOTE: We avoid calling get_image_at_index (index lookup) inside threads.
             suffix = Path(file_path).suffix.lower()
             if suffix in (".tif", ".tiff"):
                 try:
@@ -83,23 +97,20 @@ class ImageStackHandler:
             if pixels.ndim == 2:
                 return pixels
             if pixels.ndim == 3:
-                # Convert RGB/RGBA to grayscale quickly
                 return pixels.mean(axis=2)
             return pixels
 
-        # Threaded IO improves total-load time for folder stacks.
-        # (This is usually IO-bound + native decoding that releases the GIL.)
         try:
             from concurrent.futures import ThreadPoolExecutor
 
-            max_workers = min(8, len(self.files))
+            max_workers = min(8, len(included_files))
             if max_workers <= 1:
-                frames = [_load_one(p) for p in self.files]
+                frames = [_load_one(p) for p in included_files]
             else:
                 with ThreadPoolExecutor(max_workers=max_workers) as ex:
-                    frames = list(ex.map(_load_one, self.files))
+                    frames = list(ex.map(_load_one, included_files))
         except Exception:
-            frames = [_load_one(p) for p in self.files]
+            frames = [_load_one(p) for p in included_files]
 
         return np.asarray(frames)
 

--- a/src/utils/file_handler.py
+++ b/src/utils/file_handler.py
@@ -25,6 +25,12 @@ class ImageStackHandler:
         """Return total number of files regardless of exclusions."""
         return len(self.files)
 
+    def get_included_files(self) -> List[str]:
+        """Return the file list with excluded frames removed, in original order."""
+        if not self._excluded_frames:
+            return list(self.files)
+        return [p for i, p in enumerate(self.files) if i not in self._excluded_frames]
+
     def load_image_stack(self, directory_or_files) -> List[str]:
         paths: List[str] = []
         if isinstance(directory_or_files, (list, tuple)):

--- a/tests/test_analysis_panel.py
+++ b/tests/test_analysis_panel.py
@@ -1,0 +1,68 @@
+"""Tests for AnalysisPanel — tab creation and widget accessor methods."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from ui.analysis_panel import AnalysisPanel
+from ui.lomb_scargle_plot import LombScarglePlotWidget
+from ui.neuron_detection_widget import NeuronDetectionWidget
+from ui.neuron_trajectory_plot import NeuronTrajectoryPlotWidget
+from ui.rayleigh_plot import RayLeighPlotWidget
+from ui.roi_intensity_plot import ROIIntensityPlotWidget
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def test_panel_has_five_tabs(app) -> None:
+    panel = AnalysisPanel()
+    assert panel.count() == 5
+
+
+def test_tab_labels(app) -> None:
+    panel = AnalysisPanel()
+    labels = [panel.tabText(i) for i in range(panel.count())]
+    assert labels == ["Detection", "ROI Intensity", "Trajectories", "Lomb–Scargle", "Rayleigh/Rao"]
+
+
+def test_get_roi_plot_widget_returns_correct_type(app) -> None:
+    panel = AnalysisPanel()
+    assert isinstance(panel.get_roi_plot_widget(), ROIIntensityPlotWidget)
+
+
+def test_get_neuron_detection_widget_returns_correct_type(app) -> None:
+    panel = AnalysisPanel()
+    assert isinstance(panel.get_neuron_detection_widget(), NeuronDetectionWidget)
+
+
+def test_get_neuron_trajectory_plot_widget_returns_correct_type(app) -> None:
+    panel = AnalysisPanel()
+    assert isinstance(panel.get_neuron_trajectory_plot_widget(), NeuronTrajectoryPlotWidget)
+
+
+def test_get_lomb_scargle_widget_returns_correct_type(app) -> None:
+    panel = AnalysisPanel()
+    assert isinstance(panel.get_lomb_scargle_widget(), LombScarglePlotWidget)
+
+
+def test_get_rayleigh_plot_widget_returns_correct_type(app) -> None:
+    panel = AnalysisPanel()
+    assert isinstance(panel.get_rayleigh_plot_widget(), RayLeighPlotWidget)
+
+
+def test_add_tab_with_none_creates_placeholder(app) -> None:
+    panel = AnalysisPanel()
+    initial_count = panel.count()
+    panel._add_tab("Placeholder Tab")
+    assert panel.count() == initial_count + 1
+    assert panel.tabText(initial_count) == "Placeholder Tab"

--- a/tests/test_detection_progress_dialog.py
+++ b/tests/test_detection_progress_dialog.py
@@ -1,0 +1,94 @@
+"""Tests for DetectionProgressDialog — initialization, progress updates, and cancel."""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from ui.detection_progress_dialog import DetectionProgressDialog
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def test_dialog_title(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    assert dlg.windowTitle() == "Detecting Neurons..."
+
+
+def test_dialog_is_modal(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=3)
+    assert dlg.isModal() is True
+
+
+def test_dialog_minimum_size(app) -> None:
+    dlg = DetectionProgressDialog()
+    assert dlg.minimumWidth() >= 500
+    assert dlg.minimumHeight() >= 220
+
+
+def test_progress_bar_range(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=8)
+    assert dlg.progress_bar.minimum() == 0
+    assert dlg.progress_bar.maximum() == 8
+
+
+def test_progress_bar_initial_value(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    assert dlg.progress_bar.value() == 0
+
+
+def test_initial_status_label(app) -> None:
+    dlg = DetectionProgressDialog()
+    assert "Initializing" in dlg.status_label.text()
+
+
+def test_log_text_is_readonly(app) -> None:
+    dlg = DetectionProgressDialog()
+    assert dlg.log_text.isReadOnly() is True
+
+
+def test_update_progress_sets_bar_and_label(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=10)
+    dlg.update_progress(3, 10, "Detecting frame 3/10")
+    assert dlg.progress_bar.value() == 3
+    assert dlg.status_label.text() == "Detecting frame 3/10"
+
+
+def test_update_progress_clamps_to_max(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    dlg.update_progress(99, 5, "overflow")
+    assert dlg.progress_bar.value() == 5
+
+
+def test_update_progress_appends_to_log(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    dlg.update_progress(1, 5, "Step 1")
+    dlg.update_progress(2, 5, "Step 2")
+    log = dlg.log_text.toPlainText()
+    assert "Step 1" in log
+    assert "Step 2" in log
+
+
+def test_update_progress_adjusts_max_when_total_changes(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    dlg.update_progress(1, 20, "reconfig")
+    assert dlg.progress_bar.maximum() == 20
+
+
+def test_cancel_button_rejects(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=5)
+    rejected = []
+    dlg.rejected.connect(lambda: rejected.append(True))
+    dlg.show()
+    dlg.cancel_button.click()
+    assert rejected == [True]
+
+
+def test_total_steps_zero_clamps_to_one(app) -> None:
+    dlg = DetectionProgressDialog(total_steps=0)
+    assert dlg.progress_bar.maximum() >= 1

--- a/tests/test_detection_worker.py
+++ b/tests/test_detection_worker.py
@@ -1,0 +1,100 @@
+"""Tests for DetectionWorker — signal emissions and error handling."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from ui.detection_worker import DetectionWorker
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_worker(processor_result=None, processor_error=None):
+    mock_processor = Mock()
+    if processor_error:
+        mock_processor.detect_neurons_in_roi.side_effect = processor_error
+    else:
+        locations = np.array([[10, 20], [30, 40]])
+        trajectories = np.random.rand(2, 5).astype(np.float32)
+        quality = np.array([True, False])
+        mock_processor.detect_neurons_in_roi.return_value = (
+            processor_result or (locations, trajectories, quality)
+        )
+
+    frame_data = np.random.randint(0, 255, (5, 64, 64), dtype=np.uint8)
+    roi_mask = np.ones((64, 64), dtype=np.uint8)
+    params = {"cell_size": 6, "num_peaks": 100}
+
+    return DetectionWorker(mock_processor, frame_data, roi_mask, params), mock_processor
+
+
+def test_worker_emits_finished_on_success(app) -> None:
+    worker, processor = _make_worker()
+    results = []
+    worker.finished.connect(lambda loc, traj, qm: results.append((loc, traj, qm)))
+    worker.run()
+    assert len(results) == 1
+    loc, traj, qm = results[0]
+    assert loc.shape == (2, 2)
+    assert qm.shape == (2,)
+
+
+def test_worker_emits_error_on_exception(app) -> None:
+    worker, _ = _make_worker(processor_error=RuntimeError("detection failed"))
+    errors = []
+    worker.error.connect(lambda msg: errors.append(msg))
+    worker.run()
+    assert len(errors) == 1
+    assert "detection failed" in errors[0]
+
+
+def test_worker_emits_progress(app) -> None:
+    mock_processor = Mock()
+
+    def fake_detect(*args, **kwargs):
+        cb = kwargs.get("progress_callback")
+        if cb:
+            cb(1, 5, "Step 1")
+            cb(2, 5, "Step 2")
+        return np.array([[0, 0]]), np.array([[1.0]]), np.array([True])
+
+    mock_processor.detect_neurons_in_roi.side_effect = fake_detect
+
+    frame_data = np.zeros((5, 8, 8), dtype=np.uint8)
+    roi_mask = np.ones((8, 8), dtype=np.uint8)
+    worker = DetectionWorker(mock_processor, frame_data, roi_mask, {})
+
+    progress_msgs = []
+    worker.progress.connect(lambda c, t, m: progress_msgs.append((c, t, m)))
+    worker.run()
+    assert (1, 5, "Step 1") in progress_msgs
+    assert (2, 5, "Step 2") in progress_msgs
+
+
+def test_worker_passes_params_to_processor(app) -> None:
+    worker, processor = _make_worker()
+    worker._params = {
+        "cell_size": 12,
+        "num_peaks": 500,
+        "correlation_threshold": 0.6,
+        "threshold_rel": 0.05,
+        "apply_detrending": False,
+        "use_max_projection": False,
+        "preprocess_sigma": 2.0,
+    }
+    worker.run()
+    call_kwargs = processor.detect_neurons_in_roi.call_args
+    assert call_kwargs[1]["cell_size"] == 12
+    assert call_kwargs[1]["num_peaks"] == 500
+    assert call_kwargs[1]["correlation_threshold"] == 0.6
+    assert call_kwargs[1]["apply_detrending"] is False
+    assert call_kwargs[1]["preprocess_sigma"] == 2.0

--- a/tests/test_detection_worker.py
+++ b/tests/test_detection_worker.py
@@ -26,9 +26,7 @@ def _make_worker(processor_result=None, processor_error=None):
         locations = np.array([[10, 20], [30, 40]])
         trajectories = np.random.rand(2, 5).astype(np.float32)
         quality = np.array([True, False])
-        mock_processor.detect_neurons_in_roi.return_value = (
-            processor_result or (locations, trajectories, quality)
-        )
+        mock_processor.detect_neurons_in_roi.return_value = processor_result or (locations, trajectories, quality)
 
     frame_data = np.random.randint(0, 255, (5, 64, 64), dtype=np.uint8)
     roi_mask = np.ones((64, 64), dtype=np.uint8)

--- a/tests/test_draggable_spinbox.py
+++ b/tests/test_draggable_spinbox.py
@@ -1,0 +1,200 @@
+"""Tests for DraggableSpinBox and DraggableDoubleSpinBox — drag-to-adjust and tooltip."""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QMouseEvent
+from PySide6.QtWidgets import QApplication
+
+from ui.draggable_spinbox import DraggableDoubleSpinBox, DraggableSpinBox
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_mouse_event(event_type, button, pos_x, pos_y, buttons=None):
+    """Create a synthetic QMouseEvent."""
+    if buttons is None:
+        buttons = button
+    return QMouseEvent(
+        event_type,
+        QPointF(pos_x, pos_y),
+        QPointF(pos_x, pos_y),
+        button,
+        buttons,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+
+# ── DraggableSpinBox ──────────────────────────────────────────────────────
+
+
+class TestDraggableSpinBox:
+    def test_initial_cursor(self, app) -> None:
+        sb = DraggableSpinBox()
+        assert sb.cursor().shape() == Qt.CursorShape.SizeHorCursor
+
+    def test_tooltip_appends_drag_hint(self, app) -> None:
+        sb = DraggableSpinBox()
+        sb.setToolTip("Adjust value")
+        assert "Drag horizontally" in sb.toolTip()
+
+    def test_tooltip_does_not_double_hint(self, app) -> None:
+        sb = DraggableSpinBox()
+        sb.setToolTip("Adjust value")
+        sb.setToolTip(sb.toolTip())
+        assert sb.toolTip().count("Drag horizontally") == 1
+
+    def test_drag_increases_value(self, app) -> None:
+        sb = DraggableSpinBox()
+        sb.setRange(0, 100)
+        sb.setSingleStep(1)
+        sb.setValue(50)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+
+        move = _make_mouse_event(
+            QMouseEvent.Type.MouseMove,
+            Qt.MouseButton.NoButton,
+            200,
+            10,
+            buttons=Qt.MouseButton.LeftButton,
+        )
+        sb.mouseMoveEvent(move)
+        assert sb.value() > 50
+
+    def test_drag_clamps_to_range(self, app) -> None:
+        sb = DraggableSpinBox()
+        sb.setRange(0, 10)
+        sb.setSingleStep(1)
+        sb.setValue(8)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+
+        move = _make_mouse_event(
+            QMouseEvent.Type.MouseMove,
+            Qt.MouseButton.NoButton,
+            2000,
+            10,
+            buttons=Qt.MouseButton.LeftButton,
+        )
+        sb.mouseMoveEvent(move)
+        assert sb.value() <= 10
+
+    def test_release_clears_drag_state(self, app) -> None:
+        sb = DraggableSpinBox()
+        sb.setRange(0, 100)
+        sb.setValue(50)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+        assert sb._drag_start_x is not None
+
+        release = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mouseReleaseEvent(release)
+        assert sb._drag_start_x is None
+        assert sb._drag_start_value is None
+
+
+# ── DraggableDoubleSpinBox ────────────────────────────────────────────────
+
+
+class TestDraggableDoubleSpinBox:
+    def test_initial_cursor(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        assert sb.cursor().shape() == Qt.CursorShape.SizeHorCursor
+
+    def test_tooltip_appends_drag_hint(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        sb.setToolTip("Sigma value")
+        assert "Drag horizontally" in sb.toolTip()
+
+    def test_drag_changes_value(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        sb.setRange(0.0, 100.0)
+        sb.setSingleStep(0.5)
+        sb.setDecimals(2)
+        sb.setValue(50.0)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+
+        move = _make_mouse_event(
+            QMouseEvent.Type.MouseMove,
+            Qt.MouseButton.NoButton,
+            200,
+            10,
+            buttons=Qt.MouseButton.LeftButton,
+        )
+        sb.mouseMoveEvent(move)
+        assert sb.value() != 50.0
+
+    def test_drag_clamps_to_min(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        sb.setRange(0.0, 10.0)
+        sb.setSingleStep(1.0)
+        sb.setValue(2.0)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+
+        move = _make_mouse_event(
+            QMouseEvent.Type.MouseMove,
+            Qt.MouseButton.NoButton,
+            -2000,
+            10,
+            buttons=Qt.MouseButton.LeftButton,
+        )
+        sb.mouseMoveEvent(move)
+        assert sb.value() >= 0.0
+
+    def test_release_clears_drag_state(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        sb.setRange(0.0, 100.0)
+        sb.setValue(50.0)
+
+        press = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mousePressEvent(press)
+
+        release = _make_mouse_event(
+            QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10
+        )
+        sb.mouseReleaseEvent(release)
+        assert sb._drag_start_x is None
+        assert sb._drag_start_value is None
+
+    def test_move_without_press_is_noop(self, app) -> None:
+        sb = DraggableDoubleSpinBox()
+        sb.setRange(0.0, 100.0)
+        sb.setValue(50.0)
+
+        move = _make_mouse_event(
+            QMouseEvent.Type.MouseMove,
+            Qt.MouseButton.NoButton,
+            200,
+            10,
+            buttons=Qt.MouseButton.LeftButton,
+        )
+        sb.mouseMoveEvent(move)
+        assert sb.value() == 50.0

--- a/tests/test_draggable_spinbox.py
+++ b/tests/test_draggable_spinbox.py
@@ -86,7 +86,7 @@ class TestDraggableSpinBox:
             buttons=Qt.MouseButton.LeftButton,
         )
         sb.mouseMoveEvent(move)
-        assert sb.value() <= 10
+        assert sb.value() == 10
 
     def test_release_clears_drag_state(self, app) -> None:
         sb = DraggableSpinBox()
@@ -153,7 +153,7 @@ class TestDraggableDoubleSpinBox:
             buttons=Qt.MouseButton.LeftButton,
         )
         sb.mouseMoveEvent(move)
-        assert sb.value() >= 0.0
+        assert sb.value() == 0.0
 
     def test_release_clears_drag_state(self, app) -> None:
         sb = DraggableDoubleSpinBox()

--- a/tests/test_draggable_spinbox.py
+++ b/tests/test_draggable_spinbox.py
@@ -56,9 +56,7 @@ class TestDraggableSpinBox:
         sb.setSingleStep(1)
         sb.setValue(50)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
 
         move = _make_mouse_event(
@@ -77,9 +75,7 @@ class TestDraggableSpinBox:
         sb.setSingleStep(1)
         sb.setValue(8)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
 
         move = _make_mouse_event(
@@ -97,15 +93,11 @@ class TestDraggableSpinBox:
         sb.setRange(0, 100)
         sb.setValue(50)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
         assert sb._drag_start_x is not None
 
-        release = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10
-        )
+        release = _make_mouse_event(QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10)
         sb.mouseReleaseEvent(release)
         assert sb._drag_start_x is None
         assert sb._drag_start_value is None
@@ -131,9 +123,7 @@ class TestDraggableDoubleSpinBox:
         sb.setDecimals(2)
         sb.setValue(50.0)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
 
         move = _make_mouse_event(
@@ -152,9 +142,7 @@ class TestDraggableDoubleSpinBox:
         sb.setSingleStep(1.0)
         sb.setValue(2.0)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
 
         move = _make_mouse_event(
@@ -172,14 +160,10 @@ class TestDraggableDoubleSpinBox:
         sb.setRange(0.0, 100.0)
         sb.setValue(50.0)
 
-        press = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10
-        )
+        press = _make_mouse_event(QMouseEvent.Type.MouseButtonPress, Qt.MouseButton.LeftButton, 100, 10)
         sb.mousePressEvent(press)
 
-        release = _make_mouse_event(
-            QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10
-        )
+        release = _make_mouse_event(QMouseEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton, 100, 10)
         sb.mouseReleaseEvent(release)
         assert sb._drag_start_x is None
         assert sb._drag_start_value is None

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -77,7 +77,7 @@ def test_associate_with_experiment_updates_metadata() -> None:
     exp = Experiment(name="E")
     h.associate_with_experiment(exp)
     assert exp.image_count == 1
-    assert exp.image_stack_path == "/data/stack"
+    assert exp.image_stack_path == str(Path("/data/stack"))
     assert exp.image_stack_files == ["/data/stack/frame.tif"]
 
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -81,6 +81,78 @@ def test_associate_with_experiment_updates_metadata() -> None:
     assert exp.image_stack_files == ["/data/stack/frame.tif"]
 
 
+# ── Excluded-frames API ───────────────────────────────────────────────────
+
+
+def test_set_and_get_excluded_frames() -> None:
+    h = ImageStackHandler()
+    h.files = ["/a.tif", "/b.tif", "/c.tif"]
+    h.set_excluded_frames({1})
+    assert h.get_excluded_frames() == {1}
+
+
+def test_get_excluded_frames_returns_copy() -> None:
+    h = ImageStackHandler()
+    h.set_excluded_frames({0, 2})
+    result = h.get_excluded_frames()
+    result.add(99)
+    assert 99 not in h.get_excluded_frames()
+
+
+def test_get_total_frame_count() -> None:
+    h = ImageStackHandler()
+    h.files = ["/a.tif", "/b.tif", "/c.tif"]
+    h.set_excluded_frames({1})
+    assert h.get_total_frame_count() == 3
+
+
+def test_get_included_files_no_exclusions() -> None:
+    h = ImageStackHandler()
+    h.files = ["/a.tif", "/b.tif"]
+    assert h.get_included_files() == ["/a.tif", "/b.tif"]
+
+
+def test_get_included_files_with_exclusions() -> None:
+    h = ImageStackHandler()
+    h.files = ["/a.tif", "/b.tif", "/c.tif"]
+    h.set_excluded_frames({0, 2})
+    assert h.get_included_files() == ["/b.tif"]
+
+
+def test_load_stack_resets_excluded_frames(tmp_path: Path) -> None:
+    (tmp_path / "f.tif").write_bytes(b"")
+    h = ImageStackHandler()
+    h.set_excluded_frames({0, 1})
+    h.load_image_stack(str(tmp_path))
+    assert h.get_excluded_frames() == set()
+
+
+def test_get_all_frames_as_array_excludes_frames(tmp_path: Path) -> None:
+    p0 = tmp_path / "0.tif"
+    p1 = tmp_path / "1.tif"
+    p2 = tmp_path / "2.tif"
+    tifffile.imwrite(p0, np.zeros((2, 2), dtype=np.uint8))
+    tifffile.imwrite(p1, np.ones((2, 2), dtype=np.uint8) * 100)
+    tifffile.imwrite(p2, np.ones((2, 2), dtype=np.uint8) * 200)
+    h = ImageStackHandler()
+    h.load_image_stack([str(p0), str(p1), str(p2)])
+    h.set_excluded_frames({1})
+    stack = h.get_all_frames_as_array()
+    assert stack is not None
+    assert stack.shape == (2, 2, 2)
+    np.testing.assert_array_equal(stack[0], np.zeros((2, 2), dtype=np.uint8))
+    np.testing.assert_array_equal(stack[1], np.ones((2, 2), dtype=np.uint8) * 200)
+
+
+def test_get_all_frames_as_array_all_excluded(tmp_path: Path) -> None:
+    p = tmp_path / "only.tif"
+    tifffile.imwrite(p, np.zeros((2, 2), dtype=np.uint8))
+    h = ImageStackHandler()
+    h.load_image_stack([str(p)])
+    h.set_excluded_frames({0})
+    assert h.get_all_frames_as_array() is None
+
+
 @pytest.mark.parametrize(
     "raw, expected",
     [

--- a/tests/test_gif_generator.py
+++ b/tests/test_gif_generator.py
@@ -1,0 +1,46 @@
+"""Tests for GifGenerator — GIF creation, frame management, and optimize copy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from core.gif_generator import GifGenerator
+
+
+def test_generate_gif_creates_file(tmp_path: Path) -> None:
+    out = str(tmp_path / "out.gif")
+    frames = [np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(3)]
+    result = GifGenerator().generate_gif(frames, out, fps=5)
+    assert result == out
+    assert Path(out).exists()
+    assert Path(out).stat().st_size > 0
+
+
+def test_generate_gif_fps_clamped_to_one(tmp_path: Path) -> None:
+    out = str(tmp_path / "out.gif")
+    frames = [np.zeros((2, 2, 3), dtype=np.uint8)]
+    GifGenerator().generate_gif(frames, out, fps=0)
+    assert Path(out).exists()
+
+
+def test_add_frame_appends() -> None:
+    gen = GifGenerator(fps=15)
+    assert len(gen.frames) == 0
+    gen.add_frame(np.zeros((2, 2), dtype=np.uint8))
+    gen.add_frame(np.ones((2, 2), dtype=np.uint8))
+    assert len(gen.frames) == 2
+
+
+def test_init_stores_fps() -> None:
+    gen = GifGenerator(fps=24)
+    assert gen.fps == 24
+
+
+def test_optimize_gif_copies_content(tmp_path: Path) -> None:
+    src = tmp_path / "src.gif"
+    dst = tmp_path / "dst.gif"
+    src.write_bytes(b"GIFDATA123")
+    GifGenerator().optimize_gif(str(src), str(dst))
+    assert dst.read_bytes() == b"GIFDATA123"

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -1,0 +1,218 @@
+"""Tests for ImageViewer frame-culling features."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import tifffile
+from PySide6.QtWidgets import QApplication
+
+from utils.file_handler import ImageStackHandler
+from ui.image_viewer import ImageViewer
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_stack(tmp_path: Path, n: int = 5) -> list[str]:
+    """Write *n* tiny 4x4 TIFF files and return their paths."""
+    paths = []
+    for i in range(n):
+        p = tmp_path / f"frame_{i:03d}.tif"
+        tifffile.imwrite(p, np.full((4, 4), i * 10, dtype=np.uint8))
+        paths.append(str(p))
+    return paths
+
+
+@pytest.fixture
+def viewer(app, tmp_path):
+    """Create an ImageViewer loaded with a 5-frame stack."""
+    files = _make_stack(tmp_path, 5)
+    handler = ImageStackHandler()
+    v = ImageViewer(handler)
+    v.set_stack(files)
+    return v
+
+
+# ── Initial state ────────────────────────────────────────────────────────
+
+
+class TestCullingInitialState:
+    def test_excluded_frames_empty_on_init(self, viewer) -> None:
+        assert viewer.get_excluded_frames() == set()
+
+    def test_filter_excluded_off_by_default(self, viewer) -> None:
+        assert viewer._filter_excluded is False
+
+    def test_cull_panel_hidden_by_default(self, viewer) -> None:
+        assert viewer.cull_controls_panel.isVisible() is False
+
+    def test_cull_count_label_zero(self, viewer) -> None:
+        assert "0" in viewer._cull_count_label.text()
+
+
+# ── get / set excluded frames ────────────────────────────────────────────
+
+
+class TestGetSetExcludedFrames:
+    def test_set_and_get_round_trip(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        assert viewer.get_excluded_frames() == {1, 3}
+
+    def test_get_returns_copy(self, viewer) -> None:
+        viewer.set_excluded_frames({0})
+        result = viewer.get_excluded_frames()
+        result.add(99)
+        assert 99 not in viewer.get_excluded_frames()
+
+    def test_set_updates_cull_button_text(self, viewer) -> None:
+        viewer.set_excluded_frames({0})
+        viewer.index = 0
+        viewer._refresh_cull_button()
+        assert "Include" in viewer._cull_toggle_btn.text()
+
+    def test_set_updates_count_label(self, viewer) -> None:
+        viewer.set_excluded_frames({0, 2, 4})
+        assert "3" in viewer._cull_count_label.text()
+
+    def test_count_label_singular(self, viewer) -> None:
+        viewer.set_excluded_frames({2})
+        assert "1 frame excluded" in viewer._cull_count_label.text()
+
+
+# ── Cull toggle ──────────────────────────────────────────────────────────
+
+
+class TestCullToggle:
+    def test_toggle_excludes_current_frame(self, viewer) -> None:
+        viewer.index = 2
+        viewer._on_cull_toggle()
+        assert 2 in viewer.get_excluded_frames()
+
+    def test_toggle_re_includes_excluded_frame(self, viewer) -> None:
+        viewer.index = 2
+        viewer._on_cull_toggle()  # exclude
+        viewer._on_cull_toggle()  # re-include
+        assert 2 not in viewer.get_excluded_frames()
+
+    def test_toggle_emits_signal(self, viewer) -> None:
+        spy = Mock()
+        viewer.frameCullingChanged.connect(spy)
+        viewer.index = 1
+        viewer._on_cull_toggle()
+        spy.assert_called_once()
+        emitted = spy.call_args[0][0]
+        assert isinstance(emitted, set)
+        assert 1 in emitted
+
+    def test_toggle_updates_button_label(self, viewer) -> None:
+        viewer.index = 0
+        viewer._on_cull_toggle()
+        assert "Include" in viewer._cull_toggle_btn.text()
+        viewer._on_cull_toggle()
+        assert "Exclude" in viewer._cull_toggle_btn.text()
+
+
+# ── Visible indices / navigation with filter ─────────────────────────────
+
+
+class TestVisibleIndices:
+    def test_all_visible_by_default(self, viewer) -> None:
+        assert viewer._visible_indices == [0, 1, 2, 3, 4]
+
+    def test_filter_off_shows_all_even_with_exclusions(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        assert viewer._visible_indices == [0, 1, 2, 3, 4]
+
+    def test_filter_on_hides_excluded(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        viewer._filter_excluded = True
+        assert viewer._visible_indices == [0, 2, 4]
+
+
+class TestSetFilterExcluded:
+    def test_enables_filtering(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        viewer.set_filter_excluded(True)
+        assert viewer._filter_excluded is True
+        assert viewer._visible_indices == [0, 2, 4]
+
+    def test_disables_filtering(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        viewer.set_filter_excluded(True)
+        viewer.set_filter_excluded(False)
+        assert viewer._visible_indices == [0, 1, 2, 3, 4]
+
+    def test_noop_when_already_set(self, viewer) -> None:
+        viewer.set_filter_excluded(False)
+        assert viewer._filter_excluded is False
+
+    def test_snaps_to_visible_frame(self, viewer) -> None:
+        viewer.index = 1
+        viewer.set_excluded_frames({1})
+        viewer.set_filter_excluded(True)
+        assert viewer.index in viewer._visible_indices
+
+    def test_slider_range_matches_visible(self, viewer) -> None:
+        viewer.set_excluded_frames({0, 2, 4})
+        viewer.set_filter_excluded(True)
+        assert viewer.slider.maximum() == 1  # 2 visible frames → slider 0..1
+
+
+class TestNavigationWithFilter:
+    def test_next_image_skips_excluded(self, viewer) -> None:
+        viewer.set_excluded_frames({1})
+        viewer.set_filter_excluded(True)
+        viewer.index = 0
+        viewer.slider.setValue(0)
+        viewer.next_image()
+        assert viewer.index == 2
+
+    def test_prev_image_skips_excluded(self, viewer) -> None:
+        viewer.set_excluded_frames({1})
+        viewer.set_filter_excluded(True)
+        viewer.index = 2
+        viewer.slider.setValue(1)
+        viewer.prev_image()
+        assert viewer.index == 0
+
+    def test_on_slider_maps_to_visible_index(self, viewer) -> None:
+        viewer.set_excluded_frames({1, 3})
+        viewer.set_filter_excluded(True)
+        # visible = [0, 2, 4], slider pos 2 → raw index 4
+        viewer._on_slider(2)
+        assert viewer.index == 4
+
+    def test_next_at_end_stays(self, viewer) -> None:
+        viewer.set_excluded_frames({3, 4})
+        viewer.set_filter_excluded(True)
+        viewer.index = 2
+        viewer.slider.setValue(2)
+        viewer.next_image()
+        assert viewer.index == 2
+
+    def test_prev_at_start_stays(self, viewer) -> None:
+        viewer.set_filter_excluded(True)
+        viewer.index = 0
+        viewer.slider.setValue(0)
+        viewer.prev_image()
+        assert viewer.index == 0
+
+
+# ── Reset ────────────────────────────────────────────────────────────────
+
+
+class TestResetClearsExclusions:
+    def test_reset_clears_excluded_frames(self, viewer) -> None:
+        viewer.set_excluded_frames({0, 1, 2})
+        viewer.set_filter_excluded(True)
+        viewer.reset()
+        assert viewer.get_excluded_frames() == set()
+        assert viewer._filter_excluded is False

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -10,8 +10,8 @@ import pytest
 import tifffile
 from PySide6.QtWidgets import QApplication
 
-from utils.file_handler import ImageStackHandler
 from ui.image_viewer import ImageViewer
+from utils.file_handler import ImageStackHandler
 
 
 @pytest.fixture

--- a/tests/test_loading_dialog.py
+++ b/tests/test_loading_dialog.py
@@ -1,0 +1,73 @@
+"""Tests for LoadingDialog — initialization, status updates, and close."""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
+
+from ui.loading_dialog import LoadingDialog
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def test_dialog_title(app) -> None:
+    dlg = LoadingDialog()
+    assert dlg.windowTitle() == "Loading Experiment..."
+
+
+def test_dialog_is_non_modal(app) -> None:
+    dlg = LoadingDialog()
+    assert dlg.isModal() is False
+
+
+def test_dialog_minimum_size(app) -> None:
+    dlg = LoadingDialog()
+    assert dlg.minimumWidth() >= 400
+    assert dlg.minimumHeight() >= 150
+
+
+def test_dialog_stays_on_top(app) -> None:
+    dlg = LoadingDialog()
+    assert dlg.windowFlags() & Qt.WindowStaysOnTopHint
+
+
+def test_initial_labels(app) -> None:
+    dlg = LoadingDialog()
+    assert "Loading" in dlg.status_label.text()
+    assert dlg.info_label.text() == "Please wait..."
+
+
+def test_progress_bar_is_indeterminate(app) -> None:
+    dlg = LoadingDialog()
+    assert dlg.progress_bar.minimum() == 0
+    assert dlg.progress_bar.maximum() == 0
+
+
+def test_update_status_changes_labels(app) -> None:
+    dlg = LoadingDialog()
+    dlg.update_status("Processing...", "Step 2 of 5")
+    assert dlg.status_label.text() == "Processing..."
+    assert dlg.info_label.text() == "Step 2 of 5"
+
+
+def test_update_status_without_info_keeps_existing(app) -> None:
+    dlg = LoadingDialog()
+    dlg.update_status("First", "details")
+    dlg.update_status("Second")
+    assert dlg.status_label.text() == "Second"
+    assert dlg.info_label.text() == "details"
+
+
+def test_close_dialog_accepts(app) -> None:
+    dlg = LoadingDialog()
+    accepted = []
+    dlg.accepted.connect(lambda: accepted.append(True))
+    dlg.show()
+    dlg.close_dialog()
+    assert accepted == [True]

--- a/tests/test_main_window_close_exit.py
+++ b/tests/test_main_window_close_exit.py
@@ -65,6 +65,7 @@ def main_window(app, sample_experiment):
     mock_viewer.displaySettingsChanged.connect = Mock()
     mock_viewer.frameCullingChanged = Mock()
     mock_viewer.frameCullingChanged.connect = Mock()
+    mock_viewer.set_filter_excluded = Mock()
 
     mock_analysis = QWidget()
     mock_roi_plot_widget = Mock()

--- a/tests/test_main_window_close_exit.py
+++ b/tests/test_main_window_close_exit.py
@@ -63,6 +63,8 @@ def main_window(app, sample_experiment):
     mock_viewer.roiDeleted.connect = Mock()
     mock_viewer.displaySettingsChanged = Mock()
     mock_viewer.displaySettingsChanged.connect = Mock()
+    mock_viewer.frameCullingChanged = Mock()
+    mock_viewer.frameCullingChanged.connect = Mock()
 
     mock_analysis = QWidget()
     mock_roi_plot_widget = Mock()

--- a/tests/test_main_window_culling.py
+++ b/tests/test_main_window_culling.py
@@ -1,0 +1,155 @@
+"""Tests for MainWindow frame-culling integration (persistence, restore, workflow gating)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from PySide6.QtWidgets import QApplication, QWidget
+
+from core.experiment_manager import Experiment
+from ui.main_window import MainWindow
+from ui.workflow import WorkflowStep
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_main_window(app, experiment=None):
+    """Build a MainWindow with lightweight mocks, similar to existing test fixtures."""
+    exp = experiment or Experiment(name="Culling Test")
+    exp.settings = exp.settings if exp.settings else {}
+
+    mock_viewer = QWidget()
+    mock_viewer.upload_btn = Mock()
+    mock_viewer.set_stack = Mock()
+    mock_viewer.set_roi = Mock()
+    mock_viewer.set_exposure = Mock()
+    mock_viewer.set_contrast = Mock()
+    mock_viewer.get_current_roi = Mock(return_value=None)
+    mock_viewer.get_exposure = Mock(return_value=0)
+    mock_viewer.get_contrast = Mock(return_value=0)
+    mock_viewer.set_excluded_frames = Mock()
+    mock_viewer.set_filter_excluded = Mock()
+    mock_viewer.stackLoaded = Mock()
+    mock_viewer.stackLoaded.connect = Mock()
+    mock_viewer.roiSelected = Mock()
+    mock_viewer.roiSelected.connect = Mock()
+    mock_viewer.roiDeleted = Mock()
+    mock_viewer.roiDeleted.connect = Mock()
+    mock_viewer.displaySettingsChanged = Mock()
+    mock_viewer.displaySettingsChanged.connect = Mock()
+    mock_viewer.frameCullingChanged = Mock()
+    mock_viewer.frameCullingChanged.connect = Mock()
+
+    mock_analysis = QWidget()
+    mock_analysis.get_roi_plot_widget = Mock(return_value=Mock())
+    mock_analysis.get_neuron_detection_widget = Mock(return_value=Mock())
+    mock_analysis.get_neuron_trajectory_plot_widget = Mock(return_value=Mock())
+    mock_analysis.get_rayleigh_plot_widget = Mock(return_value=Mock())
+    mock_analysis.get_lomb_scargle_widget = Mock(return_value=Mock())
+
+    mock_stack_handler = Mock()
+    mock_stack_handler.files = []
+    mock_stack_handler.associate_with_experiment = Mock()
+    mock_stack_handler.get_total_frame_count = Mock(return_value=10)
+    mock_stack_handler.set_excluded_frames = Mock()
+    mock_stack_handler.get_excluded_frames = Mock(return_value=set())
+
+    with (
+        patch("ui.main_window.ImageViewer", return_value=mock_viewer),
+        patch("ui.main_window.AnalysisPanel", return_value=mock_analysis),
+        patch("ui.main_window.ImageStackHandler", return_value=mock_stack_handler),
+        patch("ui.main_window.DataAnalyzer", return_value=Mock()),
+        patch("ui.main_window.QTimer.singleShot"),
+    ):
+        window = MainWindow(exp)
+        return window
+
+
+@pytest.fixture
+def main_window(app):
+    return _make_main_window(app)
+
+
+# ── _on_frame_culling_changed ────────────────────────────────────────────
+
+
+class TestOnFrameCullingChanged:
+    def test_persists_excluded_frames_to_settings(self, main_window) -> None:
+        main_window._on_frame_culling_changed({2, 5})
+        culling = main_window.experiment.settings["culling"]
+        assert culling["excluded_frames"] == [2, 5]
+
+    def test_syncs_exclusions_to_stack_handler(self, main_window) -> None:
+        main_window._on_frame_culling_changed({0, 3})
+        main_window.stack_handler.set_excluded_frames.assert_called_with({0, 3})
+
+    def test_marks_cull_step_ready_when_not_all_excluded(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 10
+        main_window._on_frame_culling_changed({1})
+        assert main_window.workflow_manager.is_step_ready(WorkflowStep.CULL_FRAMES)
+
+    def test_revokes_readiness_when_all_excluded(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 3
+        main_window._on_frame_culling_changed({0, 1, 2})
+        assert not main_window.workflow_manager.is_step_ready(WorkflowStep.CULL_FRAMES)
+
+    def test_saves_experiment_when_path_known(self, main_window) -> None:
+        main_window.current_experiment_path = "/tmp/test.nexp"
+        with patch.object(main_window.manager, "save_experiment") as mock_save:
+            main_window._on_frame_culling_changed({1})
+            mock_save.assert_called_once()
+
+    def test_does_not_save_when_path_unknown(self, main_window) -> None:
+        main_window.current_experiment_path = None
+        with patch.object(main_window.manager, "save_experiment") as mock_save:
+            main_window._on_frame_culling_changed({1})
+            mock_save.assert_not_called()
+
+    def test_resets_downstream_when_cull_already_completed(self, main_window) -> None:
+        wm = main_window.workflow_manager
+        wm.completed_steps.add(WorkflowStep.CULL_FRAMES)
+        wm.completed_steps.add(WorkflowStep.ALIGN_IMAGES)
+        main_window.stack_handler.get_total_frame_count.return_value = 10
+        main_window._on_frame_culling_changed({2})
+        assert WorkflowStep.ALIGN_IMAGES not in wm.completed_steps
+
+
+# ── _restore_culling_state ───────────────────────────────────────────────
+
+
+class TestRestoreCullingState:
+    def test_restores_valid_entries(self, main_window) -> None:
+        main_window.experiment.settings["culling"] = {"excluded_frames": [1, 3, 7]}
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_excluded_frames.assert_called_with({1, 3, 7})
+        main_window.viewer.set_excluded_frames.assert_called_with({1, 3, 7})
+
+    def test_skips_malformed_entries(self, main_window) -> None:
+        main_window.experiment.settings["culling"] = {
+            "excluded_frames": [0, "bad", None, 4, "also_bad"]
+        }
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_excluded_frames.assert_called_with({0, 4})
+
+    def test_handles_empty_culling_section(self, main_window) -> None:
+        main_window.experiment.settings = {}
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_excluded_frames.assert_called_with(set())
+
+    def test_handles_missing_excluded_frames_key(self, main_window) -> None:
+        main_window.experiment.settings["culling"] = {}
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_excluded_frames.assert_called_with(set())
+
+    def test_coerces_string_ints(self, main_window) -> None:
+        main_window.experiment.settings["culling"] = {
+            "excluded_frames": ["2", "5"]
+        }
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_excluded_frames.assert_called_with({2, 5})

--- a/tests/test_main_window_culling.py
+++ b/tests/test_main_window_culling.py
@@ -131,9 +131,7 @@ class TestRestoreCullingState:
         main_window.viewer.set_excluded_frames.assert_called_with({1, 3, 7})
 
     def test_skips_malformed_entries(self, main_window) -> None:
-        main_window.experiment.settings["culling"] = {
-            "excluded_frames": [0, "bad", None, 4, "also_bad"]
-        }
+        main_window.experiment.settings["culling"] = {"excluded_frames": [0, "bad", None, 4, "also_bad"]}
         main_window._restore_culling_state()
         main_window.stack_handler.set_excluded_frames.assert_called_with({0, 4})
 
@@ -148,8 +146,6 @@ class TestRestoreCullingState:
         main_window.stack_handler.set_excluded_frames.assert_called_with(set())
 
     def test_coerces_string_ints(self, main_window) -> None:
-        main_window.experiment.settings["culling"] = {
-            "excluded_frames": ["2", "5"]
-        }
+        main_window.experiment.settings["culling"] = {"excluded_frames": ["2", "5"]}
         main_window._restore_culling_state()
         main_window.stack_handler.set_excluded_frames.assert_called_with({2, 5})

--- a/tests/test_main_window_time_flow.py
+++ b/tests/test_main_window_time_flow.py
@@ -40,6 +40,9 @@ def main_window(app):
     mock_viewer.roiDeleted.connect = Mock()
     mock_viewer.displaySettingsChanged = Mock()
     mock_viewer.displaySettingsChanged.connect = Mock()
+    mock_viewer.frameCullingChanged = Mock()
+    mock_viewer.frameCullingChanged.connect = Mock()
+    mock_viewer.set_filter_excluded = Mock()
 
     mock_analysis = QWidget()
     mock_analysis.get_rayleigh_plot_widget = Mock(return_value=Mock())

--- a/tests/test_startup_dialog.py
+++ b/tests/test_startup_dialog.py
@@ -1,0 +1,194 @@
+"""Tests for StartupDialog and NewExperimentDialog."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QDialog
+
+from ui.startup_dialog import NewExperimentDialog, RecentExperimentRow, StartupDialog
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+# ── RecentExperimentRow ──────────────────────────────────────────────────
+
+
+class TestRecentExperimentRow:
+    def test_row_displays_name(self, app) -> None:
+        row = RecentExperimentRow(name="Exp 1", path="/tmp/e.nexp", on_open=Mock())
+        assert row.name_label.text() == "Exp 1"
+
+    def test_row_has_options_button(self, app) -> None:
+        row = RecentExperimentRow(name="Exp 1", path="/tmp/e.nexp", on_open=Mock())
+        assert row.options_btn is not None
+        assert row.options_btn.text() == "..."
+
+    def test_double_click_calls_on_open(self, app) -> None:
+        on_open = Mock()
+        row = RecentExperimentRow(name="Exp 1", path="/tmp/e.nexp", on_open=on_open)
+        from PySide6.QtCore import QPointF
+        from PySide6.QtGui import QMouseEvent
+
+        ev = QMouseEvent(
+            QMouseEvent.Type.MouseButtonDblClick,
+            QPointF(5, 5),
+            QPointF(5, 5),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        row.mouseDoubleClickEvent(ev)
+        on_open.assert_called_once()
+
+
+# ── NewExperimentDialog ─────────────────────────────────────────────────
+
+
+class TestNewExperimentDialog:
+    def test_dialog_title(self, app) -> None:
+        dlg = NewExperimentDialog()
+        assert "New Experiment" in dlg.windowTitle()
+
+    def test_dialog_is_modal(self, app) -> None:
+        dlg = NewExperimentDialog()
+        assert dlg.isModal() is True
+
+    def test_default_date_is_today(self, app) -> None:
+        dlg = NewExperimentDialog()
+        assert datetime.utcnow().strftime("%Y-%m-%d") in dlg.date_edit.text()
+
+    def test_default_frame_interval(self, app) -> None:
+        dlg = NewExperimentDialog()
+        assert dlg.frame_interval_spin.value() == pytest.approx(30.0)
+
+    def test_analysis_combo_has_scn(self, app) -> None:
+        dlg = NewExperimentDialog()
+        assert dlg.analysis_combo.currentData() == "SCN"
+
+    def test_accept_requires_name(self, app) -> None:
+        dlg = NewExperimentDialog()
+        dlg.name_edit.setText("")
+        dlg._accept()
+        assert dlg.output_path is None
+
+    def test_accept_with_name_creates_output_path(self, app, tmp_path) -> None:
+        dlg = NewExperimentDialog()
+        dlg.name_edit.setText("TestExperiment")
+        dlg.path_edit.setText(str(tmp_path))
+        accepted = []
+        dlg.accepted.connect(lambda: accepted.append(True))
+        dlg._accept()
+        assert dlg.output_path is not None
+        assert dlg.output_path.endswith(".nexp")
+        assert dlg.metadata["name"] == "TestExperiment"
+        assert dlg.metadata["analysis_type"] == "SCN"
+
+    def test_accept_rejects_duplicate_name(self, app, tmp_path) -> None:
+        (tmp_path / "DuplicateExp.nexp").touch()
+        dlg = NewExperimentDialog()
+        dlg.name_edit.setText("DuplicateExp")
+        dlg.path_edit.setText(str(tmp_path))
+        dlg._accept()
+        assert dlg.output_path is None
+
+    def test_browse_sets_path(self, app) -> None:
+        dlg = NewExperimentDialog()
+        with patch("ui.startup_dialog.QFileDialog.getExistingDirectory", return_value="/new/path"):
+            dlg._browse()
+        assert dlg.path_edit.text() == "/new/path"
+
+    def test_browse_noop_on_cancel(self, app) -> None:
+        dlg = NewExperimentDialog()
+        original = dlg.path_edit.text()
+        with patch("ui.startup_dialog.QFileDialog.getExistingDirectory", return_value=""):
+            dlg._browse()
+        assert dlg.path_edit.text() == original
+
+
+# ── StartupDialog ────────────────────────────────────────────────────────
+
+
+class TestStartupDialog:
+    def test_dialog_title(self, app) -> None:
+        dlg = StartupDialog()
+        assert "Experiment Manager" in dlg.windowTitle()
+
+    def test_dialog_is_modal(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.isModal() is True
+
+    def test_dialog_minimum_width(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.minimumWidth() >= 520
+
+    def test_initial_experiment_is_none(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.experiment is None
+        assert dlg.experiment_path is None
+
+    def test_recent_list_exists(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.recent_list is not None
+
+    def test_settings_button_exists(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.settings_btn is not None
+
+    def test_mp_checkbox_exists(self, app) -> None:
+        dlg = StartupDialog()
+        assert dlg.enable_mp_checkbox is not None
+
+    def test_load_existing_noop_on_cancel(self, app) -> None:
+        dlg = StartupDialog()
+        with patch("ui.startup_dialog.QFileDialog.getOpenFileName", return_value=("", "")):
+            dlg._load_existing()
+        assert dlg.experiment is None
+
+    def test_load_existing_bad_file_shows_warning(self, app, tmp_path) -> None:
+        bad_file = tmp_path / "bad.nexp"
+        bad_file.write_text("not json")
+        dlg = StartupDialog()
+        with (
+            patch(
+                "ui.startup_dialog.QFileDialog.getOpenFileName",
+                return_value=(str(bad_file), ""),
+            ),
+            patch("ui.startup_dialog.QMessageBox.warning") as mock_warn,
+        ):
+            dlg._load_existing()
+        mock_warn.assert_called_once()
+        assert dlg.experiment is None
+
+    def test_start_new_noop_on_cancel(self, app) -> None:
+        dlg = StartupDialog()
+        with patch.object(NewExperimentDialog, "exec", return_value=QDialog.Rejected):
+            dlg._start_new()
+        assert dlg.experiment is None
+
+    def test_show_file_location_warns_when_missing(self, app) -> None:
+        dlg = StartupDialog()
+        with patch("ui.startup_dialog.QMessageBox.warning") as mock_warn:
+            dlg._show_file_location("/nonexistent/path.nexp")
+        mock_warn.assert_called_once()
+
+    def test_open_settings_opens_dialog(self, app) -> None:
+        dlg = StartupDialog()
+        with patch("ui.startup_dialog.SettingsDialog") as MockSettings:
+            MockSettings.return_value.exec.return_value = QDialog.Accepted
+            dlg._open_settings()
+        MockSettings.assert_called_once()
+
+    def test_mp_toggle_persists(self, app) -> None:
+        dlg = StartupDialog()
+        with patch("ui.startup_dialog.set_enable_alignment_multiprocessing") as mock_set:
+            dlg._on_alignment_mp_toggled(True)
+        mock_set.assert_called_once_with(True)

--- a/tests/test_startup_dialog.py
+++ b/tests/test_startup_dialog.py
@@ -63,8 +63,9 @@ class TestNewExperimentDialog:
         assert dlg.isModal() is True
 
     def test_default_date_is_today(self, app) -> None:
+        expected = datetime.utcnow().strftime("%Y-%m-%d")
         dlg = NewExperimentDialog()
-        assert datetime.utcnow().strftime("%Y-%m-%d") in dlg.date_edit.text()
+        assert expected in dlg.date_edit.text()
 
     def test_default_frame_interval(self, app) -> None:
         dlg = NewExperimentDialog()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -284,7 +284,7 @@ def test_infer_all_complete_sets_analyze_graphs(app) -> None:
     )
     exp.set_neuron_detection_data(neuron_locations=__import__("numpy").array([[0, 0]]))
     wm = WorkflowManager(exp)
-    assert wm.current_step == WorkflowStep.ALIGN_IMAGES or wm.current_step == WorkflowStep.ANALYZE_GRAPHS
+    assert wm.current_step == WorkflowStep.ALIGN_IMAGES
 
 
 # ── _get_next_step ───────────────────────────────────────────────────────

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,318 @@
+"""Tests for WorkflowManager — step progression, persistence, and state inference."""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from core.experiment_manager import Experiment
+from ui.workflow import (
+    STEP_DEFINITIONS,
+    StepStatus,
+    WorkflowManager,
+    WorkflowStep,
+    WorkflowStepper,
+)
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _fresh_experiment(**overrides) -> Experiment:
+    exp = Experiment(name="Test")
+    exp.settings = {}
+    for k, v in overrides.items():
+        setattr(exp, k, v)
+    return exp
+
+
+# ── STEP_DEFINITIONS constant ────────────────────────────────────────────
+
+
+def test_step_definitions_covers_all_steps() -> None:
+    for step in WorkflowStep:
+        assert step in STEP_DEFINITIONS
+
+
+def test_step_definitions_indices_are_unique() -> None:
+    indices = [m.index for m in STEP_DEFINITIONS.values()]
+    assert len(indices) == len(set(indices))
+
+
+# ── WorkflowManager init ────────────────────────────────────────────────
+
+
+def test_initial_step_is_load_images(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+
+def test_initial_completed_steps_empty(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.completed_steps == set()
+
+
+# ── get_step_status ──────────────────────────────────────────────────────
+
+
+def test_current_step_status_is_active(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.get_step_status(WorkflowStep.LOAD_IMAGES) == StepStatus.ACTIVE
+
+
+def test_locked_step_status(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.get_step_status(WorkflowStep.SELECT_ROI) == StepStatus.LOCKED
+
+
+def test_completed_step_status(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+    assert wm.get_step_status(WorkflowStep.LOAD_IMAGES) == StepStatus.COMPLETED
+
+
+# ── can_navigate_to_step ────────────────────────────────────────────────
+
+
+def test_can_navigate_to_current(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.can_navigate_to_step(WorkflowStep.LOAD_IMAGES) is True
+
+
+def test_cannot_navigate_to_locked(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.can_navigate_to_step(WorkflowStep.DETECT_NEURONS) is False
+
+
+def test_can_navigate_to_completed(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+    assert wm.can_navigate_to_step(WorkflowStep.LOAD_IMAGES) is True
+
+
+# ── complete_current_step ────────────────────────────────────────────────
+
+
+def test_complete_step_requires_ready(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.complete_current_step() is False
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+
+def test_complete_step_advances(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    assert wm.complete_current_step() is True
+    assert wm.current_step == WorkflowStep.EDIT_IMAGES
+
+
+def test_complete_step_emits_signals(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    changes = []
+    wm.step_changed.connect(lambda s: changes.append(s))
+    wm.complete_current_step()
+    assert WorkflowStep.EDIT_IMAGES in changes
+
+
+# ── complete_step_if_current ─────────────────────────────────────────────
+
+
+def test_complete_step_if_current_advances(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.complete_step_if_current(WorkflowStep.LOAD_IMAGES)
+    assert wm.current_step == WorkflowStep.EDIT_IMAGES
+
+
+def test_complete_step_if_current_noop_for_wrong_step(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.complete_step_if_current(WorkflowStep.SELECT_ROI)
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+
+# ── mark_step_ready / is_step_ready ─────────────────────────────────────
+
+
+def test_mark_step_ready(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm.is_step_ready(WorkflowStep.LOAD_IMAGES) is False
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    assert wm.is_step_ready(WorkflowStep.LOAD_IMAGES) is True
+
+
+def test_mark_step_ready_idempotent(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    assert wm.is_step_ready(WorkflowStep.LOAD_IMAGES) is True
+
+
+def test_completed_step_is_always_ready(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+    assert wm.is_step_ready(WorkflowStep.LOAD_IMAGES) is True
+
+
+def test_mark_ready_emits_state_changed_for_current(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    signals = []
+    wm.state_changed.connect(lambda: signals.append(True))
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    assert len(signals) > 0
+
+
+# ── reset_from_step ──────────────────────────────────────────────────────
+
+
+def test_reset_clears_downstream(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    for step in list(WorkflowStep)[:5]:
+        wm.mark_step_ready(step)
+        wm.complete_current_step()
+
+    wm.reset_from_step(WorkflowStep.CULL_FRAMES)
+    assert WorkflowStep.LOAD_IMAGES in wm.completed_steps
+    assert WorkflowStep.EDIT_IMAGES in wm.completed_steps
+    assert WorkflowStep.CULL_FRAMES not in wm.completed_steps
+    assert WorkflowStep.SELECT_ROI not in wm.completed_steps
+    assert wm.current_step == WorkflowStep.CULL_FRAMES
+
+
+def test_reset_clears_ready_steps(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+    wm.mark_step_ready(WorkflowStep.EDIT_IMAGES)
+    wm.reset_from_step(WorkflowStep.EDIT_IMAGES)
+    assert not wm.is_step_ready(WorkflowStep.EDIT_IMAGES)
+
+
+# ── attach_experiment / refresh_state ────────────────────────────────────
+
+
+def test_attach_experiment_replaces_state(app) -> None:
+    exp1 = _fresh_experiment()
+    exp2 = _fresh_experiment(image_stack_path="/some/path")
+    wm = WorkflowManager(exp1)
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+    wm.attach_experiment(exp2)
+    assert WorkflowStep.LOAD_IMAGES in wm.completed_steps
+
+
+# ── persist and restore ──────────────────────────────────────────────────
+
+
+def test_state_persists_to_settings(app) -> None:
+    exp = _fresh_experiment()
+    wm = WorkflowManager(exp)
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+
+    assert "workflow" in exp.settings
+    assert exp.settings["workflow"]["current_step"] == "EDIT_IMAGES"
+    assert "LOAD_IMAGES" in exp.settings["workflow"]["completed_steps"]
+
+
+def test_state_restores_from_settings(app) -> None:
+    exp = _fresh_experiment()
+    exp.settings = {
+        "workflow": {
+            "current_step": "SELECT_ROI",
+            "completed_steps": ["LOAD_IMAGES", "EDIT_IMAGES", "CULL_FRAMES", "ALIGN_IMAGES"],
+        }
+    }
+    wm = WorkflowManager(exp)
+    assert wm.current_step == WorkflowStep.SELECT_ROI
+    assert WorkflowStep.ALIGN_IMAGES in wm.completed_steps
+
+
+def test_invalid_step_name_falls_back(app) -> None:
+    exp = _fresh_experiment()
+    exp.settings = {
+        "workflow": {
+            "current_step": "INVALID_STEP_NAME",
+            "completed_steps": ["ALSO_INVALID"],
+        }
+    }
+    wm = WorkflowManager(exp)
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+    assert len(wm.completed_steps) == 0
+
+
+# ── infer state from experiment data ─────────────────────────────────────
+
+
+def test_infer_state_with_stack(app) -> None:
+    exp = _fresh_experiment(image_stack_path="/data/images")
+    wm = WorkflowManager(exp)
+    assert WorkflowStep.LOAD_IMAGES in wm.completed_steps
+    assert WorkflowStep.EDIT_IMAGES in wm.completed_steps
+    assert WorkflowStep.CULL_FRAMES in wm.completed_steps
+
+
+def test_infer_state_with_roi(app) -> None:
+    exp = _fresh_experiment(
+        image_stack_path="/data",
+        rois={"roi_1": {"x": 0, "y": 0, "width": 10, "height": 10, "shape": "ellipse"}, "roi_2": None},
+    )
+    wm = WorkflowManager(exp)
+    assert WorkflowStep.SELECT_ROI in wm.completed_steps
+
+
+def test_infer_state_with_detection(app) -> None:
+    exp = _fresh_experiment(image_stack_path="/data")
+    exp.set_neuron_detection_data(
+        neuron_locations=__import__("numpy").array([[0, 0]]),
+    )
+    wm = WorkflowManager(exp)
+    assert WorkflowStep.DETECT_NEURONS in wm.completed_steps
+    assert WorkflowStep.ANALYZE_GRAPHS in wm.completed_steps
+
+
+def test_infer_all_complete_sets_analyze_graphs(app) -> None:
+    exp = _fresh_experiment(
+        image_stack_path="/data",
+        rois={"roi_1": {"shape": "ellipse", "x": 0, "y": 0, "width": 1, "height": 1}, "roi_2": None},
+    )
+    exp.set_neuron_detection_data(neuron_locations=__import__("numpy").array([[0, 0]]))
+    wm = WorkflowManager(exp)
+    assert wm.current_step == WorkflowStep.ALIGN_IMAGES or wm.current_step == WorkflowStep.ANALYZE_GRAPHS
+
+
+# ── _get_next_step ───────────────────────────────────────────────────────
+
+
+def test_next_step_after_last_is_none(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm._get_next_step(WorkflowStep.ANALYZE_GRAPHS) is None
+
+
+def test_next_step_returns_successor(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    assert wm._get_next_step(WorkflowStep.LOAD_IMAGES) == WorkflowStep.EDIT_IMAGES
+
+
+# ── WorkflowStepper widget ──────────────────────────────────────────────
+
+
+def test_stepper_creates_buttons_for_all_steps(app) -> None:
+    exp = _fresh_experiment()
+    wm = WorkflowManager(exp)
+    stepper = WorkflowStepper(wm)
+    assert len(stepper._step_buttons) == len(WorkflowStep)
+
+
+def test_stepper_description_shows_current_step(app) -> None:
+    exp = _fresh_experiment()
+    wm = WorkflowManager(exp)
+    stepper = WorkflowStepper(wm)
+    desc_text = stepper._description_label.text()
+    assert len(desc_text) > 0


### PR DESCRIPTION
This pull request introduces a frame culling feature to the image viewer workflow, allowing users to exclude specific frames from analysis and downstream processing. It also refines test and coverage reporting configurations and improves the handling and persistence of excluded frames throughout the application. The most important changes are grouped below:

**Frame Culling Functionality in the UI:**

* Added frame culling controls to the `ImageViewer` (`src/ui/image_viewer.py`), including a new panel with "Exclude Frame" toggle, a label showing the number of excluded frames, and an overlay indicating excluded frames. Navigation logic was updated to respect excluded frames, and helper methods were added for managing and querying the culling state. [[1]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8L5-R10) [[2]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R57-R68) [[3]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R202-R217) [[4]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R230) [[5]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8L251-R280) [[6]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R302-R303) [[7]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R312) [[8]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8L395-R421) [[9]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R503-R522) [[10]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8L525-R594) [[11]](diffhunk://#diff-030ccee50c4eac926f42bc063177d1744ac62447c3298402c302c70af73fefc8R719-R775)

* Integrated the culling panel into the workflow steps in `MainWindow`, ensuring it is shown/hidden at the appropriate step and that excluded frames are hidden from navigation after culling.

**Persistence and Synchronization of Excluded Frames:**

* Excluded frames are now saved in the experiment settings and restored when reloading experiments. Changes to excluded frames are propagated to the image stack handler and neuron detection widgets to ensure consistent behavior. [[1]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R582-R586) [[2]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R739-R741) [[3]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R861-R863) [[4]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R1212-R1275)

**Downstream Effects of Culling:**

* When saving or cropping stacks, only included (non-excluded) frames are processed and named according to the filtered file list, ensuring output consistency with user culling choices. [[1]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L1276-R1368) [[2]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R1661-R1665)

**Test and Coverage Reporting Improvements:**

* Updated test and coverage configurations: removed coverage reporting from the main test run in CI (`.github/workflows/ci.yml`), and added detailed coverage options to `pyproject.toml` and a new `codecov.yml` file for more granular control and reporting. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R74) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R52-R72) [[3]](diffhunk://#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40dbR1-R24)

---

These changes collectively provide a robust frame culling workflow, ensure excluded frames are handled consistently across the application, and improve code coverage tracking and reporting.

resolves: #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add frame culling UI to mark/exclude frames, show excluded count/overlay, and APIs to get/set/restore excluded frames; navigation, preview, and exports respect included-frame indexing.

* **Workflow**
  * Insert a dedicated "Cull Frames" step; gating/readiness updated and downstream steps can be disabled if all frames are excluded.

* **Tests**
  * Add and update many UI/worker tests; adjust fixtures to mock culling interfaces and other viewer hooks.

* **CI / Config**
  * Update pytest coverage settings and add Codecov configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->