### PR TITLE
Add note recommending rigid body alignment

### DIFF
--- a/src/ui/alignment_dialog.py
+++ b/src/ui/alignment_dialog.py
@@ -53,12 +53,15 @@ class AlignmentDialog(QDialog):
         self.transform_combo = QComboBox()
         self.transform_combo.addItems(
             [
-                "Rigid Body (Translation + Rotation)",
+                "Rigid Body (Translation + Rotation) — Recommended",
                 "Translation",
                 "Scaled Rotation",
                 "Affine",
                 "Bilinear",
             ]
+        )
+        self.transform_combo.setToolTip(
+            "Rigid body alignment is recommended for most standard experiments."
         )
         self.transform_combo.setCurrentIndex(0)  # Default to Rigid Body
         self.transform_combo.currentIndexChanged.connect(self._on_transform_changed)

--- a/src/ui/alignment_dialog.py
+++ b/src/ui/alignment_dialog.py
@@ -60,9 +60,7 @@ class AlignmentDialog(QDialog):
                 "Bilinear",
             ]
         )
-        self.transform_combo.setToolTip(
-            "Rigid body alignment is recommended for most standard experiments."
-        )
+        self.transform_combo.setToolTip("Rigid body alignment is recommended for most standard experiments.")
         self.transform_combo.setCurrentIndex(0)  # Default to Rigid Body
         self.transform_combo.currentIndexChanged.connect(self._on_transform_changed)
 


### PR DESCRIPTION
This pull request makes a small improvement to the alignment dialog UI by clarifying the recommended transformation and providing additional guidance to users.

- **UI/UX Improvements:**
  * Updated the label for the "Rigid Body" transformation option in the `transform_combo` dropdown to indicate it is recommended, and added a tooltip explaining that rigid body alignment is suitable for most standard experiments. 
  
  resolves: #121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added tooltip guiding users on transformation options, recommending rigid body alignment for standard experiments.
  * Updated transformation dropdown label to highlight the recommended alignment option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->