### PR TITLE
Add a max absent neuron feature

### DIFF
--- a/src/core/image_processor.py
+++ b/src/core/image_processor.py
@@ -443,6 +443,7 @@ class ImageProcessor:
         cell_size: int = 6,
         num_peaks: int = 800,
         correlation_threshold: float = 0.4,
+        max_absent_frames: Optional[int] = None,
         threshold_rel: float = 0.03,
         apply_detrending: bool = True,
         use_max_projection: bool = True,
@@ -471,6 +472,10 @@ class ImageProcessor:
             Maximum number of neurons to detect (default: 400)
         correlation_threshold : float
             Threshold for filtering neurons by correlation (default: 0.4)
+        max_absent_frames : Optional[int]
+            Maximum number of frames where a neuron's extracted intensity can be
+            zero before it is marked bad. ``None`` preserves the current
+            behavior by allowing absence in all frames.
         threshold_rel : float
             Relative threshold for peak detection (0.0-1.0, default: 0.03).
             Lower values find dimmer neurons but may increase false positives.
@@ -653,6 +658,10 @@ class ImageProcessor:
         # Step 4: Quality Filtering (Correlation-based)
         # ============================================================
         _progress(3, "Computing quality (correlation with other neurons)...")
+        allowed_absent_frames = num_frames if max_absent_frames is None else int(max_absent_frames)
+        allowed_absent_frames = max(0, min(allowed_absent_frames, num_frames))
+        absent_frame_mask = np.count_nonzero(neuron_trajectories <= 0.0, axis=1) <= allowed_absent_frames
+
         if num_neurons > 1:
             # Compute pairwise correlations
             correlation_matrix = np.corrcoef(neuron_trajectories)
@@ -666,10 +675,10 @@ class ImageProcessor:
                 mean_correlations[i] = np.mean(other_correlations)
 
             # Filter neurons based on correlation threshold
-            quality_mask = mean_correlations > correlation_threshold
+            quality_mask = (mean_correlations > correlation_threshold) & absent_frame_mask
         else:
             # Single neuron: can't compute correlation, mark as good
-            quality_mask = np.array([True])
+            quality_mask = absent_frame_mask.astype(bool, copy=False)
 
         # ============================================================
         # Step 5: Detrending (Optional)

--- a/src/core/image_processor.py
+++ b/src/core/image_processor.py
@@ -662,23 +662,22 @@ class ImageProcessor:
         allowed_absent_frames = max(0, min(allowed_absent_frames, num_frames))
         absent_frame_mask = np.count_nonzero(neuron_trajectories <= 0.0, axis=1) <= allowed_absent_frames
 
-        if num_neurons > 1:
-            # Compute pairwise correlations
-            correlation_matrix = np.corrcoef(neuron_trajectories)
+        quality_mask = np.zeros(num_neurons, dtype=bool)
+        present_indices = np.flatnonzero(absent_frame_mask)
 
-            # For each neuron, compute mean correlation with all other neurons
-            # (excluding self-correlation which is always 1.0)
-            mean_correlations = np.zeros(num_neurons)
-            for i in range(num_neurons):
-                # Get correlations with all other neurons (exclude self)
+        if len(present_indices) > 1:
+            correlation_matrix = np.corrcoef(neuron_trajectories[present_indices])
+
+            mean_correlations = np.zeros(len(present_indices), dtype=np.float32)
+            for i in range(len(present_indices)):
                 other_correlations = np.delete(correlation_matrix[i], i)
                 mean_correlations[i] = np.mean(other_correlations)
 
-            # Filter neurons based on correlation threshold
-            quality_mask = (mean_correlations > correlation_threshold) & absent_frame_mask
-        else:
-            # Single neuron: can't compute correlation, mark as good
-            quality_mask = absent_frame_mask.astype(bool, copy=False)
+            quality_mask[present_indices] = mean_correlations > correlation_threshold
+        elif len(present_indices) == 1:
+            quality_mask[present_indices[0]] = True
+
+        quality_mask &= absent_frame_mask
 
         # ============================================================
         # Step 5: Detrending (Optional)

--- a/src/ui/detection_worker.py
+++ b/src/ui/detection_worker.py
@@ -44,6 +44,7 @@ class DetectionWorker(QThread):
                 cell_size=self._params.get("cell_size", 6),
                 num_peaks=self._params.get("num_peaks", 800),
                 correlation_threshold=self._params.get("correlation_threshold", 0.4),
+                max_absent_frames=self._params.get("max_absent_frames"),
                 threshold_rel=self._params.get("threshold_rel", 0.03),
                 apply_detrending=self._params.get("apply_detrending", True),
                 use_max_projection=self._params.get("use_max_projection", True),

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -904,6 +904,7 @@ class MainWindow(QMainWindow):
                         "cell_size": detection_widget.cell_size_spin.value(),
                         "num_peaks": detection_widget.num_peaks_spin.value(),
                         "correlation_threshold": (detection_widget.correlation_threshold_spin.value()),
+                        "max_absent_frames": detection_widget.max_absent_frames_spin.value(),
                         "threshold_rel": detection_widget.threshold_rel_spin.value(),
                         "apply_detrending": detection_widget.detrending_checkbox.isChecked(),
                     }

--- a/src/ui/neuron_detection_widget.py
+++ b/src/ui/neuron_detection_widget.py
@@ -57,6 +57,7 @@ class NeuronDetectionWidget(QWidget):
         self._detection_progress_dialog: Optional[DetectionProgressDialog] = None
         self._detection_worker: Optional[DetectionWorker] = None
         self._loaded_roi_origin: Optional[np.ndarray] = None
+        self._max_absent_frames_default = 0
 
         main_layout = QHBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
@@ -104,6 +105,15 @@ class NeuronDetectionWidget(QWidget):
         self.correlation_threshold_spin.setDecimals(2)
         self.correlation_threshold_spin.setToolTip("Threshold for filtering neurons by correlation quality")
         params_layout.addRow("Correlation Threshold:", self.correlation_threshold_spin)
+
+        self.max_absent_frames_spin = DraggableSpinBox()
+        self.max_absent_frames_spin.setRange(0, 0)
+        self.max_absent_frames_spin.setValue(0)
+        self.max_absent_frames_spin.setToolTip(
+            "Maximum number of frames where a neuron's extracted intensity can be zero before it is marked bad. "
+            "Defaults to the total frame count, which preserves current behavior."
+        )
+        params_layout.addRow("Max Absent Frames:", self.max_absent_frames_spin)
 
         self.threshold_rel_spin = DraggableDoubleSpinBox()
         self.threshold_rel_spin.setRange(0.0, 1.0)
@@ -195,6 +205,7 @@ class NeuronDetectionWidget(QWidget):
     def set_frame_data(self, frame_data: Optional[np.ndarray]) -> None:
         """Set the frame data (3D array: frames, height, width)."""
         self.frame_data = frame_data
+        self._sync_max_absent_frames_with_stack(reset_to_default=True)
         self._update_ui_state()
 
     def set_roi_mask(self, roi_key: str, roi_mask: Optional[np.ndarray]) -> None:
@@ -301,10 +312,14 @@ class NeuronDetectionWidget(QWidget):
             self._display_frame = None
 
         # Restore detection parameters if available
+        self._sync_max_absent_frames_with_stack(reset_to_default=False)
         if detection_params:
             self.cell_size_spin.setValue(detection_params.get("cell_size", 8))
             self.num_peaks_spin.setValue(detection_params.get("num_peaks", 800))
             self.correlation_threshold_spin.setValue(detection_params.get("correlation_threshold", 0.5))
+            self.max_absent_frames_spin.setValue(
+                detection_params.get("max_absent_frames", self._max_absent_frames_default)
+            )
             self.threshold_rel_spin.setValue(detection_params.get("threshold_rel", 0.06))
             self.detrending_checkbox.setChecked(detection_params.get("apply_detrending", True))
 
@@ -354,6 +369,17 @@ class NeuronDetectionWidget(QWidget):
             return m1 | m2
         return m1 if m1 is not None else m2
 
+    def _sync_max_absent_frames_with_stack(self, reset_to_default: bool) -> None:
+        """Keep absent-frame limits aligned to the loaded stack size."""
+        num_frames = int(self.frame_data.shape[0]) if self.frame_data is not None else 0
+        previous_default = self._max_absent_frames_default
+        self._max_absent_frames_default = num_frames
+        self.max_absent_frames_spin.setRange(0, num_frames)
+        if reset_to_default or self.max_absent_frames_spin.value() == previous_default:
+            self.max_absent_frames_spin.setValue(num_frames)
+        else:
+            self.max_absent_frames_spin.setValue(min(self.max_absent_frames_spin.value(), num_frames))
+
     def _update_ui_state(self) -> None:
         """Update UI state based on available data and selected mode."""
         mask = self._effective_mask()
@@ -392,6 +418,7 @@ class NeuronDetectionWidget(QWidget):
             "cell_size": self.cell_size_spin.value(),
             "num_peaks": self.num_peaks_spin.value(),
             "correlation_threshold": self.correlation_threshold_spin.value(),
+            "max_absent_frames": self.max_absent_frames_spin.value(),
             "threshold_rel": self.threshold_rel_spin.value(),
             "apply_detrending": self.detrending_checkbox.isChecked(),
             "use_max_projection": self.max_projection_checkbox.isChecked(),
@@ -482,6 +509,7 @@ class NeuronDetectionWidget(QWidget):
                 "cell_size": self.cell_size_spin.value(),
                 "num_peaks": self.num_peaks_spin.value(),
                 "correlation_threshold": self.correlation_threshold_spin.value(),
+                "max_absent_frames": self.max_absent_frames_spin.value(),
                 "threshold_rel": self.threshold_rel_spin.value(),
                 "apply_detrending": self.detrending_checkbox.isChecked(),
             }

--- a/src/ui/neuron_detection_widget.py
+++ b/src/ui/neuron_detection_widget.py
@@ -207,9 +207,7 @@ class NeuronDetectionWidget(QWidget):
         previous_default = self._max_absent_frames_default
         current_value = self.max_absent_frames_spin.value()
         self.frame_data = frame_data
-        self._sync_max_absent_frames_with_stack(
-            reset_to_default=current_value == previous_default
-        )
+        self._sync_max_absent_frames_with_stack(reset_to_default=current_value == previous_default)
         self._update_ui_state()
 
     def set_roi_mask(self, roi_key: str, roi_mask: Optional[np.ndarray]) -> None:

--- a/src/ui/neuron_detection_widget.py
+++ b/src/ui/neuron_detection_widget.py
@@ -314,14 +314,22 @@ class NeuronDetectionWidget(QWidget):
             self._display_frame = None
 
         # Restore detection parameters if available
-        self._sync_max_absent_frames_with_stack(reset_to_default=False)
+        saved_max_absent_frames = self._max_absent_frames_default
+        if detection_params is not None:
+            saved_max_absent_frames = int(
+                detection_params.get("max_absent_frames", self._max_absent_frames_default)
+            )
+
+        if self.frame_data is not None:
+            self._sync_max_absent_frames_with_stack(reset_to_default=False)
+        else:
+            self.max_absent_frames_spin.setRange(0, max(saved_max_absent_frames, 0))
+
         if detection_params:
             self.cell_size_spin.setValue(detection_params.get("cell_size", 8))
             self.num_peaks_spin.setValue(detection_params.get("num_peaks", 800))
             self.correlation_threshold_spin.setValue(detection_params.get("correlation_threshold", 0.5))
-            self.max_absent_frames_spin.setValue(
-                detection_params.get("max_absent_frames", self._max_absent_frames_default)
-            )
+            self.max_absent_frames_spin.setValue(saved_max_absent_frames)
             self.threshold_rel_spin.setValue(detection_params.get("threshold_rel", 0.06))
             self.detrending_checkbox.setChecked(detection_params.get("apply_detrending", True))
 
@@ -356,6 +364,7 @@ class NeuronDetectionWidget(QWidget):
                 roi_origin=roi_origin,
             )
         self._loaded_roi_origin = None  # Clear so next run uses computed
+
 
     def _effective_mask(self) -> Optional[np.ndarray]:
         """Return the combined boolean mask for the currently selected detection mode."""

--- a/src/ui/neuron_detection_widget.py
+++ b/src/ui/neuron_detection_widget.py
@@ -316,9 +316,7 @@ class NeuronDetectionWidget(QWidget):
         # Restore detection parameters if available
         saved_max_absent_frames = self._max_absent_frames_default
         if detection_params is not None:
-            saved_max_absent_frames = int(
-                detection_params.get("max_absent_frames", self._max_absent_frames_default)
-            )
+            saved_max_absent_frames = int(detection_params.get("max_absent_frames", self._max_absent_frames_default))
 
         if self.frame_data is not None:
             self._sync_max_absent_frames_with_stack(reset_to_default=False)
@@ -364,7 +362,6 @@ class NeuronDetectionWidget(QWidget):
                 roi_origin=roi_origin,
             )
         self._loaded_roi_origin = None  # Clear so next run uses computed
-
 
     def _effective_mask(self) -> Optional[np.ndarray]:
         """Return the combined boolean mask for the currently selected detection mode."""

--- a/src/ui/neuron_detection_widget.py
+++ b/src/ui/neuron_detection_widget.py
@@ -204,8 +204,12 @@ class NeuronDetectionWidget(QWidget):
 
     def set_frame_data(self, frame_data: Optional[np.ndarray]) -> None:
         """Set the frame data (3D array: frames, height, width)."""
+        previous_default = self._max_absent_frames_default
+        current_value = self.max_absent_frames_spin.value()
         self.frame_data = frame_data
-        self._sync_max_absent_frames_with_stack(reset_to_default=True)
+        self._sync_max_absent_frames_with_stack(
+            reset_to_default=current_value == previous_default
+        )
         self._update_ui_state()
 
     def set_roi_mask(self, roi_key: str, roi_mask: Optional[np.ndarray]) -> None:

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,3 +1,6 @@
+import sys
+import types
+
 import cv2
 import numpy as np
 import pytest
@@ -465,6 +468,92 @@ def test_detect_neurons_in_roi_with_detrending():
         apply_detrending=True,
     )
     assert isinstance(trajs, np.ndarray)
+
+
+def test_detect_neurons_in_roi_applies_max_absent_frames_culling():
+    processor = _make_processor()
+    stack = np.zeros((5, 30, 30), dtype=np.uint16)
+
+    stable_levels = [300, 450, 600, 750, 900]
+    transient_levels = [900, 700, 0, 0, 0]
+
+    for frame_idx, level in enumerate(stable_levels):
+        stack[frame_idx, 6, 6] = level
+        stack[frame_idx, 6, 7] = max(level // 2, 1)
+        stack[frame_idx, 7, 6] = max(level // 2, 1)
+
+    for frame_idx, level in enumerate(transient_levels):
+        if level > 0:
+            stack[frame_idx, 22, 22] = level
+            stack[frame_idx, 22, 23] = max(level // 2, 1)
+            stack[frame_idx, 23, 22] = max(level // 2, 1)
+
+    roi_mask = np.ones((30, 30), dtype=bool)
+
+    scipy_module = types.ModuleType("scipy")
+    ndimage_module = types.ModuleType("scipy.ndimage")
+    signal_module = types.ModuleType("scipy.signal")
+    skimage_module = types.ModuleType("skimage")
+    feature_module = types.ModuleType("skimage.feature")
+    morphology_module = types.ModuleType("skimage.morphology")
+
+    ndimage_module.gaussian_filter = lambda array, sigma, mode, cval: array
+    signal_module.savgol_filter = lambda trajectory, window_length, polyorder: trajectory
+    feature_module.peak_local_max = lambda *args, **kwargs: np.array([[6, 6], [22, 22]], dtype=np.int32)
+    morphology_module.disk = lambda radius: np.ones((radius * 2 + 1, radius * 2 + 1), dtype=bool)
+
+    original_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "scipy",
+            "scipy.ndimage",
+            "scipy.signal",
+            "skimage",
+            "skimage.feature",
+            "skimage.morphology",
+        )
+    }
+    sys.modules["scipy"] = scipy_module
+    sys.modules["scipy.ndimage"] = ndimage_module
+    sys.modules["scipy.signal"] = signal_module
+    sys.modules["skimage"] = skimage_module
+    sys.modules["skimage.feature"] = feature_module
+    sys.modules["skimage.morphology"] = morphology_module
+
+    try:
+        locs_default, _, quality_default = processor.detect_neurons_in_roi(
+            stack,
+            roi_mask,
+            cell_size=3,
+            num_peaks=10,
+            correlation_threshold=-1.1,
+            threshold_rel=0.1,
+            apply_detrending=False,
+        )
+        locs_limited, _, quality_limited = processor.detect_neurons_in_roi(
+            stack,
+            roi_mask,
+            cell_size=3,
+            num_peaks=10,
+            correlation_threshold=-1.1,
+            max_absent_frames=2,
+            threshold_rel=0.1,
+            apply_detrending=False,
+        )
+    finally:
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    default_by_location = {tuple(loc): bool(is_good) for loc, is_good in zip(locs_default, quality_default)}
+    limited_by_location = {tuple(loc): bool(is_good) for loc, is_good in zip(locs_limited, quality_limited)}
+
+    assert default_by_location[(6, 6)] is True
+    assert default_by_location[(22, 22)] is True
+    assert limited_by_location[(6, 6)] is True
+    assert limited_by_location[(22, 22)] is False
 
 
 def test_detect_neurons_in_roi_raises_for_2d_frame_data():

--- a/tests/test_neuron_detection_widget.py
+++ b/tests/test_neuron_detection_widget.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QApplication, QWidget
+
+# The test environment does not always install matplotlib, but this widget only
+# needs lightweight stubs for construction in this test.
+matplotlib_module = types.ModuleType("matplotlib")
+backends_module = types.ModuleType("matplotlib.backends")
+backend_qtagg_module = types.ModuleType("matplotlib.backends.backend_qtagg")
+figure_module = types.ModuleType("matplotlib.figure")
+
+
+class _DummyCanvas(QWidget):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+
+class _DummyFigure:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+backend_qtagg_module.FigureCanvasQTAgg = _DummyCanvas
+figure_module.Figure = _DummyFigure
+
+sys.modules.setdefault("matplotlib", matplotlib_module)
+sys.modules.setdefault("matplotlib.backends", backends_module)
+sys.modules.setdefault("matplotlib.backends.backend_qtagg", backend_qtagg_module)
+sys.modules.setdefault("matplotlib.figure", figure_module)
+
+from ui.neuron_detection_widget import NeuronDetectionWidget
+
+
+@pytest.fixture
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        return QApplication([])
+    return app
+
+
+def test_max_absent_frames_defaults_to_stack_length(qapp: QApplication) -> None:
+    widget = NeuronDetectionWidget()
+    widget.set_frame_data(np.zeros((7, 12, 12), dtype=np.float32))
+
+    assert widget.max_absent_frames_spin.minimum() == 0
+    assert widget.max_absent_frames_spin.maximum() == 7
+    assert widget.max_absent_frames_spin.value() == 7

--- a/tests/test_neuron_detection_widget.py
+++ b/tests/test_neuron_detection_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 
@@ -33,7 +34,7 @@ sys.modules.setdefault("matplotlib.backends", backends_module)
 sys.modules.setdefault("matplotlib.backends.backend_qtagg", backend_qtagg_module)
 sys.modules.setdefault("matplotlib.figure", figure_module)
 
-from ui.neuron_detection_widget import NeuronDetectionWidget
+NeuronDetectionWidget = importlib.import_module("ui.neuron_detection_widget").NeuronDetectionWidget
 
 
 @pytest.fixture


### PR DESCRIPTION
Allow the user to select how many frames a neuron can be absent before it is marked as a bad neuron. resolves: #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Max Absent Frames" detection parameter to filter neurons that are missing across frames.
  * Detection now combines correlation-based quality checks with the new absent-frame criterion.

* **Tests**
  * Added unit tests validating absent-frame culling behavior and the UI control defaulting to the stack length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->