### PR TITLE
fix: update CD workflow for Windows PyInstaller

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         include:
           - runner: windows-latest
-            exe_name: neurolight-${{ github.ref_name }}-windows-amd64.exe
+            exe_name: neurolight-${{ github.ref_name }}-windows-amd64.zip
             artifact_name: exe-windows
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -128,7 +128,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p release-asset
-          cp dist/Neurolight/Neurolight.exe "release-asset/${{ matrix.exe_name }}"
+          cd dist
+          7z a -tzip "../release-asset/${{ matrix.exe_name }}" Neurolight/
 
       - name: Upload executable artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the Windows build process in the GitHub Actions workflow to package the Windows executable as a `.zip` archive instead of a raw `.exe` file. This change ensures that the Windows release artifact is distributed as a zipped folder, which is more standard and compatible for users.

**Workflow changes for Windows release packaging:**

* Changed the artifact file name for Windows builds from `.exe` to `.zip` in the workflow matrix (`.github/workflows/cd.yml`).
* Updated the release asset creation step to zip the entire `Neurolight` directory using `7z`, instead of copying just the `.exe` file, ensuring all necessary files are included in the release (`.github/workflows/cd.yml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows release packaging in the CI/CD workflow to distribute as `.zip` archives instead of raw `.exe` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->