### PR TITLE
fix the issues with experiment time being asked again when loading th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 
 # App data
 experiments/*
+users/*
 !experiments/.gitkeep
 ~/.neurolight/
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -862,17 +862,21 @@ class MainWindow(QMainWindow):
         self.workflow_manager.mark_step_ready(WorkflowStep.CULL_FRAMES)
 
     def _confirm_start_time_from_loaded_stack(self) -> None:
-        """Always prompt to confirm start time immediately after loading a stack."""
+        """Prompt once for start time when the experiment does not already have one saved."""
         if not self.stack_handler.files:
             return
+        acquisition = self.experiment.settings.get("acquisition") or {}
+        existing_time = acquisition.get("experiment_start_time")
+        if _parse_time_string(existing_time) is not None:
+            return
+
         first_file = self.stack_handler.files[0]
         inferred = _get_exif_timestamp(first_file)
         qtime = _parse_time_string(inferred)
 
         if qtime is None:
             # Fall back to currently saved acquisition time, then midnight.
-            acquisition = self.experiment.settings.get("acquisition") or {}
-            qtime = _parse_time_string(acquisition.get("experiment_start_time")) or QTime(0, 0, 0)
+            qtime = _parse_time_string(existing_time) or QTime(0, 0, 0)
 
         uniformity_note = None
         if len(self.stack_handler.files) > 1:

--- a/tests/test_main_window_time_flow.py
+++ b/tests/test_main_window_time_flow.py
@@ -118,6 +118,21 @@ def test_confirm_start_time_from_loaded_stack_accept_updates_settings(main_windo
     main_window.experiment.update_modified_date.assert_called_once()
 
 
+def test_confirm_start_time_from_loaded_stack_skips_prompt_when_time_already_saved(main_window):
+    main_window.stack_handler.files = ["/tmp/a.tif"]
+    main_window.experiment.settings = {"acquisition": {"experiment_start_time": "08:00:00"}}
+
+    with (
+        patch("ui.main_window._get_exif_timestamp") as get_exif_timestamp,
+        patch("ui.main_window._ConfirmStartTimeDialog") as confirm_dialog,
+    ):
+        main_window._confirm_start_time_from_loaded_stack()
+
+    get_exif_timestamp.assert_not_called()
+    confirm_dialog.assert_not_called()
+    assert main_window.experiment.settings["acquisition"]["experiment_start_time"] == "08:00:00"
+
+
 def test_confirm_start_time_from_loaded_stack_cancel_keeps_existing(main_window):
     main_window.stack_handler.files = ["/tmp/a.tif"]
     main_window.experiment.settings = {"acquisition": {"experiment_start_time": "08:00:00"}}


### PR DESCRIPTION
Experiment time was being asked every  time I load the experiment up. Now it should be saved to the experiment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experiment start time workflow: the application now skips redundant confirmation prompts when the start time is already saved in settings, directly using the stored value instead.

* **Tests**
  * Added test coverage for saved start time validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->