### PR TITLE
Fix hdiutil 'Resource busy' error on macOS CI by detaching stale volumes

### DIFF
--- a/build-macos-dmg.sh
+++ b/build-macos-dmg.sh
@@ -28,6 +28,7 @@ cp -R "$APP" "$DMG_STAGE/"
 ln -s /Applications "$DMG_STAGE/Applications"
 
 echo "Creating DMG..."
+hdiutil detach "/Volumes/$VOL_NAME" 2>/dev/null || true
 hdiutil create \
   -volname "$VOL_NAME" \
   -srcfolder "$DMG_STAGE" \


### PR DESCRIPTION
Detach any previously mounted volume with the same name before creating the DMG, preventing failures when a prior run left the volume attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of macOS DMG builds by preventing mount conflicts during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->