### PR TITLE
Minor pop up fix

### DIFF
--- a/src/ui/help_content.py
+++ b/src/ui/help_content.py
@@ -57,4 +57,3 @@ HELP_TEXT: Final[dict[str, str]] = {
 def get_help_text(help_id: str) -> str:
     """Return help text for a given ID, or a fallback."""
     return HELP_TEXT.get(help_id, "Help is not available for this item yet.")
-

--- a/src/ui/help_content.py
+++ b/src/ui/help_content.py
@@ -1,0 +1,60 @@
+"""Plain-language help text for key analysis metrics and plots.
+
+Keep these short: users should understand the takeaway in a few seconds.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+HELP_TEXT: Final[dict[str, str]] = {
+    # Lomb–Scargle
+    "lomb_scargle.plot": (
+        "Lomb–Scargle periodogram\n\n"
+        "Shows how strong different repeating cycle lengths are in the ROI intensity trace.\n"
+        "A taller peak suggests a more prominent rhythm at that frequency/period.\n\n"
+        "Tip: In Period mode, the x-axis is cycle length (minutes per cycle). In Frequency mode, it is cycles per minute."
+    ),
+    "lomb_scargle.summary": (
+        "Peak readout\n\n"
+        "f*: peak frequency (where the periodogram is highest)\n"
+        "P(f*): power at the peak (higher usually means a stronger rhythm)\n"
+        "T*: peak period (cycle length) = 1 / f*"
+    ),
+    "lomb_scargle.interval": (
+        "Sampling interval\n\n"
+        "Time between frames (in minutes). This sets the time scale for the periodogram.\n"
+        "Use the same interval that was used to acquire the images."
+    ),
+    "lomb_scargle.axis_mode": (
+        "X-axis mode\n\n"
+        "Frequency: cycles per minute.\n"
+        "Period: minutes per cycle (cycle length).\n\n"
+        "Both views show the same information, just in different units."
+    ),
+    # Rayleigh / Rao
+    "rayleigh.plot": (
+        "Peak times on a 24-hour circle\n\n"
+        "Each dot is a neuron. Its angle shows when that neuron reaches its peak activity (modulo 24 hours).\n"
+        "If dots cluster at a particular time-of-day, peak times are more synchronized."
+    ),
+    "rayleigh.stats": (
+        "Rayleigh test (circular uniformity)\n\n"
+        "Tests whether peak times are spread evenly across the day or clustered.\n"
+        "r: clustering strength (0 = spread out, 1 = tightly clustered)\n"
+        "p: smaller values suggest the peaks are not uniform (i.e., more clustered than expected by chance)."
+    ),
+    "rao.stats": (
+        "Rao's spacing test (circular uniformity)\n\n"
+        "Another test for whether peak times are evenly spaced around the 24-hour circle.\n"
+        "U: spacing statistic (larger values indicate less-uniform spacing)\n"
+        "p: smaller values suggest non-uniform peak times."
+    ),
+}
+
+
+def get_help_text(help_id: str) -> str:
+    """Return help text for a given ID, or a fallback."""
+    return HELP_TEXT.get(help_id, "Help is not available for this item yet.")
+

--- a/src/ui/help_content.py
+++ b/src/ui/help_content.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 
 from typing import Final
 
-
 HELP_TEXT: Final[dict[str, str]] = {
     # Lomb–Scargle
     "lomb_scargle.plot": (
         "Lomb–Scargle periodogram\n\n"
         "Shows how strong different repeating cycle lengths are in the ROI intensity trace.\n"
         "A taller peak suggests a more prominent rhythm at that frequency/period.\n\n"
-        "Tip: In Period mode, the x-axis is cycle length (minutes per cycle). In Frequency mode, it is cycles per minute."
+        "Tip: In Period mode, the x-axis is cycle length (minutes per cycle).\n"
+        "In Frequency mode, it is cycles per minute."
     ),
     "lomb_scargle.summary": (
         "Peak readout\n\n"

--- a/src/ui/help_widgets.py
+++ b/src/ui/help_widgets.py
@@ -48,4 +48,3 @@ class HelpIconButton(QToolButton):
         # Show tooltip slightly below the icon to avoid covering labels.
         pos = self.mapToGlobal(QPoint(self.width() // 2, self.height()))
         QToolTip.showText(pos, self._tooltip, self)
-

--- a/src/ui/help_widgets.py
+++ b/src/ui/help_widgets.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QFontMetrics
+from PySide6.QtWidgets import QToolButton, QToolTip, QWidget
+
+from ui.help_content import get_help_text
+
+
+class HelpIconButton(QToolButton):
+    """Small non-obstructive help icon that shows a tooltip/popover on hover/click."""
+
+    def __init__(
+        self,
+        help_id: str,
+        *,
+        tooltip: Optional[str] = None,
+        parent: Optional[QWidget] = None,
+        accessible_name: Optional[str] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._help_id = help_id
+        self._tooltip = tooltip if tooltip is not None else get_help_text(help_id)
+
+        # Visuals: small icon-like button that doesn't steal attention.
+        self.setText("ⓘ")
+        self.setAutoRaise(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.setProperty("class", "help-icon")
+        self.setToolTip(self._tooltip)
+
+        name = accessible_name or f"Help: {help_id}"
+        self.setAccessibleName(name)
+        self.setAccessibleDescription(self._tooltip)
+
+        # Keep footprint tiny.
+        fm = QFontMetrics(self.font())
+        size = max(18, fm.height() + 4)
+        self.setFixedSize(size, size)
+
+        # Clicking should also show the tooltip (useful for touch/trackpad users).
+        self.clicked.connect(self._show_tooltip_now)
+
+    def _show_tooltip_now(self) -> None:
+        # Show tooltip slightly below the icon to avoid covering labels.
+        pos = self.mapToGlobal(QPoint(self.width() // 2, self.height()))
+        QToolTip.showText(pos, self._tooltip, self)
+

--- a/src/ui/loading_dialog.py
+++ b/src/ui/loading_dialog.py
@@ -19,8 +19,9 @@ class LoadingDialog(QDialog):
         self.setMinimumWidth(400)
         self.setMinimumHeight(150)
 
-        # Make it stay on top and visible
-        self.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.CustomizeWindowHint | Qt.WindowStaysOnTopHint)
+        # Keep this as a normal (non always-on-top) dialog so modal dialogs like
+        # "Confirm Experiment Start Time" can appear in front of it.
+        self.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.CustomizeWindowHint)
 
         layout = QVBoxLayout(self)
         layout.setSpacing(15)

--- a/src/ui/lomb_scargle_plot.py
+++ b/src/ui/lomb_scargle_plot.py
@@ -23,6 +23,8 @@ from core.lomb_scargle import compute_lomb_scargle
 from ui.app_settings import get_theme
 from ui.constants import DEFAULT_FRAME_INTERVAL_MINUTES, ROI_DISPLAY_NAMES, ROI_KEYS
 from ui.draggable_spinbox import DraggableDoubleSpinBox
+from ui.help_content import get_help_text
+from ui.help_widgets import HelpIconButton
 from ui.styles import get_mpl_theme
 
 
@@ -53,6 +55,19 @@ class LombScarglePlotWidget(QWidget):
         self.status_label.setWordWrap(True)
         layout.addWidget(self.status_label)
 
+        # Title row with contextual help (non-obstructive)
+        title_row_widget = QWidget()
+        title_row = QHBoxLayout(title_row_widget)
+        title_row.setContentsMargins(4, 0, 4, 0)
+        title_row.setSpacing(6)
+        title_row.addStretch()
+        title_label = QLabel("Lomb–Scargle Periodogram")
+        title_label.setStyleSheet("font-size: 15px; font-weight: 700;")
+        title_row.addWidget(title_label)
+        title_row.addWidget(HelpIconButton("lomb_scargle.plot", accessible_name="Help: Lomb–Scargle periodogram"))
+        title_row.addStretch()
+        layout.addWidget(title_row_widget)
+
         # Compact single-row controls strip
         controls_row = QHBoxLayout()
         controls_row.setContentsMargins(4, 2, 4, 2)
@@ -74,7 +89,8 @@ class LombScarglePlotWidget(QWidget):
         controls_row.addSpacing(12)
 
         # Sampling interval
-        controls_row.addWidget(QLabel("Interval (min):"))
+        interval_label = QLabel("Interval (min):")
+        controls_row.addWidget(interval_label)
         self.sampling_interval_spin = DraggableDoubleSpinBox()
         self.sampling_interval_spin.setRange(0.0001, 10_000.0)
         self.sampling_interval_spin.setDecimals(4)
@@ -84,16 +100,21 @@ class LombScarglePlotWidget(QWidget):
         self.sampling_interval_spin.setToolTip(
             "Time between successive frames in minutes.\nSet this to match the experiment's acquisition interval."
         )
+        interval_label.setToolTip(get_help_text("lomb_scargle.interval"))
+        self.sampling_interval_spin.setToolTip(get_help_text("lomb_scargle.interval"))
         self.sampling_interval_spin.valueChanged.connect(self._update_plot)
         controls_row.addWidget(self.sampling_interval_spin)
 
         controls_row.addSpacing(12)
 
         # X-axis mode
-        controls_row.addWidget(QLabel("X-axis:"))
+        axis_label = QLabel("X-axis:")
+        axis_label.setToolTip(get_help_text("lomb_scargle.axis_mode"))
+        controls_row.addWidget(axis_label)
         self.axis_mode_combo = QComboBox()
         self.axis_mode_combo.addItem("Frequency", self.AXIS_FREQ)
         self.axis_mode_combo.addItem("Period", self.AXIS_PERIOD)
+        self.axis_mode_combo.setToolTip(get_help_text("lomb_scargle.axis_mode"))
         self.axis_mode_combo.currentIndexChanged.connect(self._update_plot)
         controls_row.addWidget(self.axis_mode_combo)
 
@@ -113,7 +134,17 @@ class LombScarglePlotWidget(QWidget):
         self.summary_label.setAlignment(Qt.AlignCenter)
         self.summary_label.setProperty("class", "plot-hover")
         self.summary_label.setStyleSheet("font-size: 14px; font-weight: 600; margin-top: 4px; margin-bottom: 4px;")
+        self.summary_label.setToolTip(get_help_text("lomb_scargle.summary"))
         layout.addWidget(self.summary_label)
+
+        # Subtle help icon next to the summary (clickable for users who don't hover)
+        summary_help_row_widget = QWidget()
+        summary_help_row = QHBoxLayout(summary_help_row_widget)
+        summary_help_row.setContentsMargins(0, 0, 0, 0)
+        summary_help_row.addStretch()
+        summary_help_row.addWidget(HelpIconButton("lomb_scargle.summary", accessible_name="Help: peak readout"))
+        summary_help_row.addStretch()
+        layout.addWidget(summary_help_row_widget)
 
         # Export buttons
         buttons_layout = QHBoxLayout()

--- a/src/ui/rayleigh_plot.py
+++ b/src/ui/rayleigh_plot.py
@@ -33,6 +33,8 @@ from PySide6.QtWidgets import (
 from core.circular_stats import rao_spacing_test, rayleigh_test
 from ui.app_settings import get_theme
 from ui.constants import DEFAULT_FRAME_INTERVAL_MINUTES
+from ui.help_content import get_help_text
+from ui.help_widgets import HelpIconButton
 from ui.styles import get_mpl_theme
 
 
@@ -133,26 +135,46 @@ class RayLeighPlotWidget(QWidget):
         stats_container = QVBoxLayout()
         stats_container.setSpacing(4)
 
+        rayleigh_title_row_widget = QWidget()
+        rayleigh_title_row = QHBoxLayout(rayleigh_title_row_widget)
+        rayleigh_title_row.setContentsMargins(0, 0, 0, 0)
+        rayleigh_title_row.setSpacing(6)
+        rayleigh_title_row.addStretch()
         self.rayleigh_title_label = QLabel("Rayleigh:")
         self.rayleigh_title_label.setAlignment(Qt.AlignCenter)
         self.rayleigh_title_label.setStyleSheet("font-size: 16px; font-weight: 700; color: #4A90E2;")
-        stats_container.addWidget(self.rayleigh_title_label)
+        self.rayleigh_title_label.setToolTip(get_help_text("rayleigh.stats"))
+        rayleigh_title_row.addWidget(self.rayleigh_title_label)
+        rayleigh_title_row.addWidget(HelpIconButton("rayleigh.stats", accessible_name="Help: Rayleigh test"))
+        rayleigh_title_row.addStretch()
+        stats_container.addWidget(rayleigh_title_row_widget)
 
         self.rayleigh_stats_label = QLabel("")
         self.rayleigh_stats_label.setAlignment(Qt.AlignCenter)
         self.rayleigh_stats_label.setWordWrap(True)
         self.rayleigh_stats_label.setStyleSheet("font-size: 14px; font-weight: 500;")
+        self.rayleigh_stats_label.setToolTip(get_help_text("rayleigh.stats"))
         stats_container.addWidget(self.rayleigh_stats_label)
 
+        rao_title_row_widget = QWidget()
+        rao_title_row = QHBoxLayout(rao_title_row_widget)
+        rao_title_row.setContentsMargins(0, 0, 0, 0)
+        rao_title_row.setSpacing(6)
+        rao_title_row.addStretch()
         self.rao_title_label = QLabel("Rao:")
         self.rao_title_label.setAlignment(Qt.AlignCenter)
         self.rao_title_label.setStyleSheet("font-size: 16px; font-weight: 700; color: #4A90E2; margin-top: 6px;")
-        stats_container.addWidget(self.rao_title_label)
+        self.rao_title_label.setToolTip(get_help_text("rao.stats"))
+        rao_title_row.addWidget(self.rao_title_label)
+        rao_title_row.addWidget(HelpIconButton("rao.stats", accessible_name="Help: Rao's spacing test"))
+        rao_title_row.addStretch()
+        stats_container.addWidget(rao_title_row_widget)
 
         self.rao_stats_label = QLabel("")
         self.rao_stats_label.setAlignment(Qt.AlignCenter)
         self.rao_stats_label.setWordWrap(True)
         self.rao_stats_label.setStyleSheet("font-size: 14px; font-weight: 500;")
+        self.rao_stats_label.setToolTip(get_help_text("rao.stats"))
         stats_container.addWidget(self.rao_stats_label)
 
         sidebar_layout.addLayout(stats_container)
@@ -172,6 +194,7 @@ class RayLeighPlotWidget(QWidget):
         self.figure = Figure(figsize=(6, 6))
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.canvas.setToolTip(get_help_text("rayleigh.plot"))
         self.toolbar = NavigationToolbar(self.canvas, self)
         self.toolbar.setObjectName("mpl_nav_toolbar")
         plot_layout.addWidget(self.toolbar)

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -854,6 +854,26 @@ def get_stylesheet(theme: str = "dark") -> str:
         font-size: {FONT_SIZE_SMALL};
     }}
 
+    /* Inline help icon (small, non-obstructive) */
+    QToolButton[class="help-icon"] {{
+        background-color: transparent;
+        color: {c["text_secondary"]};
+        border: 1px solid {c["border"]};
+        border-radius: 9px;
+        padding: 0px;
+        font-weight: 700;
+    }}
+
+    QToolButton[class="help-icon"]:hover {{
+        color: {c["primary"]};
+        border-color: {c["primary"]};
+        background-color: {c["hover"]};
+    }}
+
+    QToolButton[class="help-icon"]:focus {{
+        border-color: {c["border_focus"]};
+    }}
+
     /* === Workflow stepper (top process bar) === */
     QFrame[objectName="workflowStepper"] {{
         background-color: {c["surface"]};

--- a/tests/test_loading_dialog.py
+++ b/tests/test_loading_dialog.py
@@ -32,9 +32,9 @@ def test_dialog_minimum_size(app) -> None:
     assert dlg.minimumHeight() >= 150
 
 
-def test_dialog_stays_on_top(app) -> None:
+def test_dialog_is_not_always_on_top(app) -> None:
     dlg = LoadingDialog()
-    assert dlg.windowFlags() & Qt.WindowStaysOnTopHint
+    assert not (dlg.windowFlags() & Qt.WindowStaysOnTopHint)
 
 
 def test_initial_labels(app) -> None:


### PR DESCRIPTION
Removed flag that forces the "loading image stack" popup to the front as it blocked the "confirm test start time" popup and could lead the user to wait infinitely for the image stack to be loaded when that's not happening yet. This makes sure what the user needs to see is properly seen in order to they confirm what the test start time is, then wait for the image stack to load when it's actually loading.