### PR TITLE
Adding bracket image culling for better efficiency

### DIFF
--- a/src/ui/image_viewer.py
+++ b/src/ui/image_viewer.py
@@ -751,6 +751,8 @@ class ImageViewer(QWidget):
     def _visible_indices(self) -> list:
         """Raw file indices the viewer should navigate through."""
         total = self.handler.get_image_count()
+        if total == 0:
+            return []
         if not self._filter_excluded or self._cull_end < 0:
             return list(range(total))
         start = max(0, min(self._cull_start, total - 1))

--- a/src/ui/image_viewer.py
+++ b/src/ui/image_viewer.py
@@ -764,6 +764,11 @@ class ImageViewer(QWidget):
         if self._filter_excluded == enabled:
             return
         self._filter_excluded = enabled
+        self._sync_nav_to_visible()
+        self._show_current()
+
+    def _sync_nav_to_visible(self) -> None:
+        """Resync the nav slider bounds and current index to _visible_indices."""
         vis = self._visible_indices
         if not vis:
             return
@@ -773,7 +778,6 @@ class ImageViewer(QWidget):
             self.index = vis[0]
         self.slider.setValue(vis.index(self.index))
         self.slider.blockSignals(False)
-        self._show_current()
 
     def get_cull_range(self) -> tuple:
         """Return (start_frame, end_frame) of the current included range."""
@@ -789,11 +793,15 @@ class ImageViewer(QWidget):
             self._cull_start = start
             self._cull_end = end
         self._range_slider.set_values(self._cull_start, self._cull_end)
+        if self._filter_excluded:
+            self._sync_nav_to_visible()
         self._show_current()
 
     def _on_range_changed(self, start: int, end: int) -> None:
         self._cull_start = start
         self._cull_end = end
+        if self._filter_excluded:
+            self._sync_nav_to_visible()
         self._show_current()
         self.frameCullingChanged.emit(start, end)
 

--- a/src/ui/image_viewer.py
+++ b/src/ui/image_viewer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Optional, Set
+from typing import Dict, Optional
 
 import cv2
 import numpy as np
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 from core.roi import ROI, ROIShape
 from ui.app_settings import get_roi_colors
 from ui.constants import ROI_DISPLAY_NAMES, ROI_KEYS
+from ui.range_slider import DualHandleRangeSlider
 from utils.file_handler import ImageStackHandler
 from utils.image_utils import numpy_to_qimage
 
@@ -55,7 +56,7 @@ class ImageViewer(QWidget):
     roiChanged = Signal(str, object)  # Emits (roi_key, ROI object) when adjusted
     roiDeleted = Signal(str)  # Emits roi_key when an ROI is deleted
     displaySettingsChanged = Signal(int, int)  # Emits (exposure, contrast) when display settings change
-    frameCullingChanged = Signal(object)  # Emits set of excluded frame indices
+    frameCullingChanged = Signal(int, int)  # Emits (start_frame, end_frame) of included range
 
     def __init__(self, handler: ImageStackHandler) -> None:
         super().__init__()
@@ -63,8 +64,9 @@ class ImageViewer(QWidget):
         self.index = 0
         self.cache = _LRUCache(20)
 
-        # Frame culling state
-        self._excluded_frames: Set[int] = set()
+        # Frame culling state — range-based (inclusive, 0-indexed; -1 means unset)
+        self._cull_start: int = 0
+        self._cull_end: int = -1
         self._filter_excluded: bool = False
 
         # Dual ROI state
@@ -207,16 +209,13 @@ class ImageViewer(QWidget):
         # Frame culling panel (shown only during Cull Frames workflow step)
         self.cull_controls_panel = QWidget()
         cull_panel_layout = QVBoxLayout(self.cull_controls_panel)
-        cull_panel_layout.setContentsMargins(0, 0, 0, 0)
-        cull_panel_layout.setSpacing(4)
+        cull_panel_layout.setContentsMargins(0, 4, 0, 0)
+        cull_panel_layout.setSpacing(0)
 
-        self._cull_toggle_btn = QPushButton("Exclude Frame")
-        self._cull_toggle_btn.setCheckable(True)
-        self._cull_toggle_btn.clicked.connect(self._on_cull_toggle)
-        cull_panel_layout.addWidget(self._cull_toggle_btn)
-
-        self._cull_count_label = QLabel("0 frames excluded")
-        cull_panel_layout.addWidget(self._cull_count_label)
+        self._range_slider = DualHandleRangeSlider()
+        self._range_slider.range_changed.connect(self._on_range_changed)
+        self._range_slider.frame_preview_requested.connect(self._on_frame_preview)
+        cull_panel_layout.addWidget(self._range_slider)
 
         self.cull_controls_panel.setVisible(False)
 
@@ -275,6 +274,15 @@ class ImageViewer(QWidget):
 
     def set_stack(self, files) -> None:
         self.handler.load_image_stack(files)
+        total = self.handler.get_image_count()
+        if total > 0:
+            self._cull_start = 0
+            self._cull_end = total - 1
+            self._range_slider.set_total(total)
+        else:
+            self._cull_start = 0
+            self._cull_end = -1
+            self._range_slider.set_total(0)
         vis = self._visible_indices
         self.slider.setRange(0, max(0, len(vis) - 1))
         self.index = vis[0] if vis else 0
@@ -304,8 +312,10 @@ class ImageViewer(QWidget):
         self.handler.files = []
         self.index = 0
         self.cache = _LRUCache(20)
-        self._excluded_frames = set()
+        self._cull_start = 0
+        self._cull_end = -1
         self._filter_excluded = False
+        self._range_slider.set_total(0)
         self.current_rois = {"roi_1": None, "roi_2": None}
         self.active_roi_key = "roi_1"
         self._populate_roi_selector()
@@ -314,7 +324,6 @@ class ImageViewer(QWidget):
         self.frame_index_label.setText("— / —")
         self.slider.setRange(0, 0)
         self._update_roi_button_text()
-        self._refresh_cull_button()
         self.prev_btn.setEnabled(True)
         self.next_btn.setEnabled(True)
         self.slider.setEnabled(True)
@@ -505,26 +514,25 @@ class ImageViewer(QWidget):
                 painter.drawEllipse(x_scaled, y_scaled, w_scaled, h_scaled)
             painter.end()
 
-        # Draw "EXCLUDED" overlay when current frame is culled
-        if self.index in self._excluded_frames:
-            painter = QPainter(scaled_pix)
-            overlay_color = QColor(180, 40, 40, 100)
-            painter.fillRect(scaled_pix.rect(), overlay_color)
-            painter.setPen(QPen(QColor(255, 60, 60, 220)))
-            font = QFont()
-            font.setPixelSize(max(20, scaled_pix.height() // 8))
-            font.setBold(True)
-            painter.setFont(font)
-            painter.drawText(scaled_pix.rect(), Qt.AlignCenter, "EXCLUDED")
-            painter.end()
+        # Draw "EXCLUDED" overlay when browsing frames outside the included range
+        if not self._filter_excluded and self._cull_end >= 0:
+            if self.index < self._cull_start or self.index > self._cull_end:
+                painter = QPainter(scaled_pix)
+                overlay_color = QColor(180, 40, 40, 100)
+                painter.fillRect(scaled_pix.rect(), overlay_color)
+                painter.setPen(QPen(QColor(255, 60, 60, 220)))
+                font = QFont()
+                font.setPixelSize(max(20, scaled_pix.height() // 8))
+                font.setBold(True)
+                painter.setFont(font)
+                painter.drawText(scaled_pix.rect(), Qt.AlignCenter, "EXCLUDED")
+                painter.end()
 
         self.image_label.setPixmap(scaled_pix)
         current_path = Path(self.handler.files[self.index])
         display_pos = vis.index(self.index) + 1 if self.index in vis else self.index + 1
         self._update_frame_index_label(count)
         self.filename_label.setText(f"{display_pos}/{count}: \n{current_path.name}")
-
-        self._refresh_cull_button()
 
     def resizeEvent(self, event) -> None:  # noqa: N802
         # ROI FIX: Redraw on resize so ROI scale updates correctly
@@ -743,12 +751,14 @@ class ImageViewer(QWidget):
     def _visible_indices(self) -> list:
         """Raw file indices the viewer should navigate through."""
         total = self.handler.get_image_count()
-        if not self._filter_excluded or not self._excluded_frames:
+        if not self._filter_excluded or self._cull_end < 0:
             return list(range(total))
-        return [i for i in range(total) if i not in self._excluded_frames]
+        start = max(0, min(self._cull_start, total - 1))
+        end = max(start, min(self._cull_end, total - 1))
+        return list(range(start, end + 1))
 
     def set_filter_excluded(self, enabled: bool) -> None:
-        """Toggle whether excluded frames are hidden from navigation."""
+        """Toggle whether only included-range frames are shown in navigation."""
         if self._filter_excluded == enabled:
             return
         self._filter_excluded = enabled
@@ -757,37 +767,35 @@ class ImageViewer(QWidget):
             return
         self.slider.blockSignals(True)
         self.slider.setRange(0, max(0, len(vis) - 1))
-        # Snap current index to the nearest visible frame
         if self.index not in vis:
             self.index = vis[0]
         self.slider.setValue(vis.index(self.index))
         self.slider.blockSignals(False)
         self._show_current()
 
-    def get_excluded_frames(self) -> Set[int]:
-        return set(self._excluded_frames)
+    def get_cull_range(self) -> tuple:
+        """Return (start_frame, end_frame) of the current included range."""
+        return (self._cull_start, self._cull_end)
 
-    def set_excluded_frames(self, indices: Set[int]) -> None:
-        """Restore excluded frames (e.g. from saved experiment), without emitting."""
-        self._excluded_frames = set(indices)
-        self._refresh_cull_button()
-        self._show_current()
-
-    def _on_cull_toggle(self) -> None:
-        if self.index in self._excluded_frames:
-            self._excluded_frames.discard(self.index)
+    def set_cull_range(self, start: int, end: int) -> None:
+        """Restore included range (e.g. from saved experiment), without emitting."""
+        total = self.handler.get_image_count()
+        if total > 0:
+            self._cull_start = max(0, min(start, total - 1))
+            self._cull_end = max(self._cull_start, min(end, total - 1))
         else:
-            self._excluded_frames.add(self.index)
-        self._refresh_cull_button()
+            self._cull_start = start
+            self._cull_end = end
+        self._range_slider.set_values(self._cull_start, self._cull_end)
         self._show_current()
-        self.frameCullingChanged.emit(set(self._excluded_frames))
 
-    def _refresh_cull_button(self) -> None:
-        is_excluded = self.index in self._excluded_frames
-        self._cull_toggle_btn.blockSignals(True)
-        self._cull_toggle_btn.setChecked(is_excluded)
-        self._cull_toggle_btn.blockSignals(False)
-        self._cull_toggle_btn.setText("Include Frame" if is_excluded else "Exclude Frame")
+    def _on_range_changed(self, start: int, end: int) -> None:
+        self._cull_start = start
+        self._cull_end = end
+        self._show_current()
+        self.frameCullingChanged.emit(start, end)
 
-        n = len(self._excluded_frames)
-        self._cull_count_label.setText(f"{n} frame{'s' if n != 1 else ''} excluded")
+    def _on_frame_preview(self, frame: int) -> None:
+        """Jump to frame requested by range slider handle drag."""
+        self.index = frame
+        self._show_current()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1318,16 +1318,15 @@ class MainWindow(QMainWindow):
         if self.workflow_manager.current_step == WorkflowStep.EDIT_IMAGES:
             self.workflow_manager.mark_step_ready(WorkflowStep.EDIT_IMAGES)
 
-    def _on_frame_culling_changed(self, excluded: set) -> None:
-        """Persist excluded frames to experiment and sync to the stack handler."""
+    def _on_frame_culling_changed(self, start: int, end: int) -> None:
+        """Persist included frame range to experiment and sync to the stack handler."""
         if "culling" not in self.experiment.settings:
             self.experiment.settings["culling"] = {}
-        self.experiment.settings["culling"]["excluded_frames"] = sorted(excluded)
-        self.stack_handler.set_excluded_frames(excluded)
+        self.experiment.settings["culling"]["start_frame"] = start
+        self.experiment.settings["culling"]["end_frame"] = end
+        self.stack_handler.set_included_range(start, end)
 
         # Keep neuron detection input in sync with the included-only stack.
-        # Detection operates on the frame_data provided to the widget; if culling
-        # changes after load, we must refresh it.
         try:
             if hasattr(self, "analysis"):
                 detection_widget = self.analysis.get_neuron_detection_widget()
@@ -1337,10 +1336,9 @@ class MainWindow(QMainWindow):
             pass
 
         total = self.stack_handler.get_total_frame_count()
-        all_excluded = total > 0 and len(excluded) >= total
+        no_frames = total == 0 or start > end
 
-        if all_excluded:
-            # Cannot advance with zero included frames — remove readiness
+        if no_frames:
             self.workflow_manager._ready_steps.discard(WorkflowStep.CULL_FRAMES)
             self.workflow_manager.state_changed.emit()
         else:
@@ -1349,7 +1347,7 @@ class MainWindow(QMainWindow):
         # If culling changed after downstream steps completed, invalidate them
         if WorkflowStep.CULL_FRAMES in self.workflow_manager.completed_steps:
             self.workflow_manager.reset_from_step(WorkflowStep.CULL_FRAMES)
-            if not all_excluded:
+            if not no_frames:
                 self.workflow_manager.mark_step_ready(WorkflowStep.CULL_FRAMES)
 
         if self.current_experiment_path:
@@ -1359,20 +1357,21 @@ class MainWindow(QMainWindow):
                 pass
 
     def _restore_culling_state(self) -> None:
-        """Restore excluded frames from experiment settings into viewer and handler."""
+        """Restore included frame range from experiment settings into viewer and handler."""
         culling = self.experiment.settings.get("culling") or {}
-        excluded_list = culling.get("excluded_frames", [])
-        excluded: set[int] = set()
-        skipped = 0
-        for item in excluded_list:
-            try:
-                excluded.add(int(item))
-            except (ValueError, TypeError):
-                skipped += 1
-        if skipped:
-            logger.warning("Skipped %d malformed excluded-frame entries", skipped)
-        self.stack_handler.set_excluded_frames(excluded)
-        self.viewer.set_excluded_frames(excluded)
+        total = self.stack_handler.get_total_frame_count()
+        try:
+            start = int(culling.get("start_frame", 0))
+        except (ValueError, TypeError):
+            start = 0
+        try:
+            end = int(culling.get("end_frame", max(0, total - 1)))
+        except (ValueError, TypeError):
+            end = max(0, total - 1)
+        start = max(0, min(start, max(0, total - 1)))
+        end = max(start, min(end, max(0, total - 1)))
+        self.stack_handler.set_included_range(start, end)
+        self.viewer.set_cull_range(start, end)
 
         # Ensure detection uses the included-only stack after restoring culling.
         try:

--- a/src/ui/range_slider.py
+++ b/src/ui/range_slider.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor, QFont, QPainter, QPen
+from PySide6.QtWidgets import QWidget
+
+
+class DualHandleRangeSlider(QWidget):
+    """Dual-handle range slider for selecting a contiguous frame range.
+
+    Signals:
+        range_changed(start, end): Emitted on mouse release (0-indexed).
+        frame_preview_requested(frame): Emitted live during drag (0-indexed).
+    """
+
+    range_changed = Signal(int, int)
+    frame_preview_requested = Signal(int)
+
+    _HANDLE_RADIUS = 9
+    _TRACK_HEIGHT = 6
+    _LABEL_H = 20
+    _PAD = 16
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._total: int = 0
+        self._start: int = 0
+        self._end: int = 0
+        self._dragging: str | None = None
+        self.setMinimumHeight(60)
+        self.setMouseTracking(True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_total(self, total: int) -> None:
+        """Set total frames and reset range to include all."""
+        self._total = max(0, total)
+        self._start = 0
+        self._end = max(0, self._total - 1)
+        self.update()
+
+    def set_values(self, start: int, end: int) -> None:
+        """Set current range without emitting signals."""
+        if self._total <= 0:
+            return
+        self._start = max(0, min(start, self._total - 1))
+        self._end = max(self._start, min(end, self._total - 1))
+        self.update()
+
+    def get_start(self) -> int:
+        return self._start
+
+    def get_end(self) -> int:
+        return self._end
+
+    # ------------------------------------------------------------------
+    # Geometry
+    # ------------------------------------------------------------------
+
+    def _usable_w(self) -> int:
+        return max(1, self.width() - 2 * self._PAD)
+
+    def _frame_to_x(self, frame: int) -> int:
+        if self._total <= 1:
+            return self._PAD + self._usable_w() // 2
+        return self._PAD + round(frame / (self._total - 1) * self._usable_w())
+
+    def _x_to_frame(self, x: int) -> int:
+        if self._total <= 1:
+            return 0
+        ratio = (x - self._PAD) / self._usable_w()
+        return max(0, min(self._total - 1, round(ratio * (self._total - 1))))
+
+    def _track_y(self) -> int:
+        return self._LABEL_H + self._HANDLE_RADIUS + 4
+
+    # ------------------------------------------------------------------
+    # Paint
+    # ------------------------------------------------------------------
+
+    def paintEvent(self, event) -> None:  # noqa: N802
+        if self._total <= 0:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        ty = self._track_y()
+        hh = self._TRACK_HEIGHT // 2
+        xs = self._frame_to_x(self._start)
+        xe = self._frame_to_x(self._end)
+        tl = self._PAD
+        tr = self._PAD + self._usable_w()
+
+        excluded_col = QColor(70, 70, 70)
+        included_col = QColor(70, 140, 220)
+
+        # left excluded region
+        if xs > tl:
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(excluded_col)
+            painter.drawRoundedRect(tl, ty - hh, xs - tl, self._TRACK_HEIGHT, 3, 3)
+
+        # included region
+        inc_w = max(0, xe - xs)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(included_col)
+        painter.drawRoundedRect(xs, ty - hh, inc_w, self._TRACK_HEIGHT, 3, 3)
+
+        # right excluded region
+        if xe < tr:
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(excluded_col)
+            painter.drawRoundedRect(xe, ty - hh, tr - xe, self._TRACK_HEIGHT, 3, 3)
+
+        # handles and frame labels
+        font = QFont()
+        font.setPixelSize(11)
+        painter.setFont(font)
+        fm = painter.fontMetrics()
+
+        for x, label in (
+            (xs, f"Frame {self._start + 1}"),
+            (xe, f"Frame {self._end + 1}"),
+        ):
+            r = self._HANDLE_RADIUS
+            painter.setPen(QPen(QColor(180, 180, 180), 2))
+            painter.setBrush(QColor(240, 240, 240))
+            painter.drawEllipse(x - r, ty - r, r * 2, r * 2)
+
+            painter.setPen(QColor(200, 200, 200))
+            tw = fm.horizontalAdvance(label)
+            tx = max(0, min(x - tw // 2, self.width() - tw))
+            painter.drawText(tx, self._LABEL_H - 4, label)
+
+        painter.end()
+
+    # ------------------------------------------------------------------
+    # Mouse events
+    # ------------------------------------------------------------------
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802
+        if self._total <= 0:
+            return
+        x = event.position().x()
+        xs = self._frame_to_x(self._start)
+        xe = self._frame_to_x(self._end)
+        hit = self._HANDLE_RADIUS + 4
+
+        ds = abs(x - xs)
+        de = abs(x - xe)
+
+        if ds <= hit and (ds <= de or de > hit):
+            self._dragging = "start"
+        elif de <= hit:
+            self._dragging = "end"
+
+    def mouseMoveEvent(self, event) -> None:  # noqa: N802
+        if self._dragging is None or self._total <= 0:
+            return
+        frame = self._x_to_frame(int(event.position().x()))
+        if self._dragging == "start":
+            frame = min(frame, self._end)
+            if frame != self._start:
+                self._start = frame
+                self.update()
+                self.frame_preview_requested.emit(self._start)
+        else:
+            frame = max(frame, self._start)
+            if frame != self._end:
+                self._end = frame
+                self.update()
+                self.frame_preview_requested.emit(self._end)
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        if self._dragging is not None:
+            self._dragging = None
+            self.range_changed.emit(self._start, self._end)

--- a/src/utils/file_handler.py
+++ b/src/utils/file_handler.py
@@ -95,7 +95,9 @@ class ImageStackHandler:
         if self._included_end < 0:
             return list(self.files)
         start = max(0, min(self._included_start, len(self.files) - 1))
-        end = max(start, min(self._included_end, len(self.files) - 1))
+        end = max(0, min(self._included_end, len(self.files) - 1))
+        if start > end:
+            return []
         return self.files[start : end + 1]
 
     def load_image_stack(self, directory_or_files) -> List[str]:

--- a/src/utils/file_handler.py
+++ b/src/utils/file_handler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List, Optional
 
 import numpy as np
 from PIL import Image
@@ -72,23 +72,31 @@ class ImageStackHandler:
     def __init__(self) -> None:
         self.files: List[str] = []
         self._experiment: Optional[Experiment] = None
-        self._excluded_frames: Set[int] = set()
+        self._included_start: int = 0
+        self._included_end: int = -1  # -1 means "all frames"
 
-    def set_excluded_frames(self, indices: Set[int]) -> None:
-        self._excluded_frames = set(indices)
+    def set_included_range(self, start: int, end: int) -> None:
+        """Set the inclusive range of frames to treat as included."""
+        self._included_start = start
+        self._included_end = end
 
-    def get_excluded_frames(self) -> Set[int]:
-        return set(self._excluded_frames)
+    def get_included_range(self) -> tuple:
+        """Return (start, end) of the current included range."""
+        return (self._included_start, self._included_end)
 
     def get_total_frame_count(self) -> int:
-        """Return total number of files regardless of exclusions."""
+        """Return total number of files regardless of the included range."""
         return len(self.files)
 
     def get_included_files(self) -> List[str]:
-        """Return the file list with excluded frames removed, in original order."""
-        if not self._excluded_frames:
+        """Return the file list trimmed to the included range, in original order."""
+        if not self.files:
+            return []
+        if self._included_end < 0:
             return list(self.files)
-        return [p for i, p in enumerate(self.files) if i not in self._excluded_frames]
+        start = max(0, min(self._included_start, len(self.files) - 1))
+        end = max(start, min(self._included_end, len(self.files) - 1))
+        return self.files[start : end + 1]
 
     def load_image_stack(self, directory_or_files) -> List[str]:
         paths: List[str] = []
@@ -104,7 +112,8 @@ class ImageStackHandler:
                     if p.is_file() and p.suffix.lower() in (".tif", ".tiff"):
                         paths.append(str(p))
         self.files = paths
-        self._excluded_frames = set()
+        self._included_start = 0
+        self._included_end = -1
         return self.files
 
     def validate_tif_files(self, file_paths: List[str]) -> bool:
@@ -134,13 +143,13 @@ class ImageStackHandler:
             return np.asarray(img)
 
     def get_all_frames_as_array(self) -> Optional[np.ndarray]:
-        """Load all non-excluded frames as a 3D numpy array (frames, height, width).
+        """Load all included-range frames as a 3D numpy array (frames, height, width).
         Preserves original image dtype to avoid precision loss (consistent with get_image_at_index).
         """
         if not self.files:
             return None
 
-        included_files = [p for i, p in enumerate(self.files) if i not in self._excluded_frames]
+        included_files = self.get_included_files()
         if not included_files:
             return None
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -84,50 +84,43 @@ def test_associate_with_experiment_updates_metadata() -> None:
 # ── Excluded-frames API ───────────────────────────────────────────────────
 
 
-def test_set_and_get_excluded_frames() -> None:
+def test_set_and_get_included_range() -> None:
     h = ImageStackHandler()
     h.files = ["/a.tif", "/b.tif", "/c.tif"]
-    h.set_excluded_frames({1})
-    assert h.get_excluded_frames() == {1}
-
-
-def test_get_excluded_frames_returns_copy() -> None:
-    h = ImageStackHandler()
-    h.set_excluded_frames({0, 2})
-    result = h.get_excluded_frames()
-    result.add(99)
-    assert 99 not in h.get_excluded_frames()
+    h.set_included_range(1, 2)
+    assert h.get_included_range() == (1, 2)
 
 
 def test_get_total_frame_count() -> None:
     h = ImageStackHandler()
     h.files = ["/a.tif", "/b.tif", "/c.tif"]
-    h.set_excluded_frames({1})
+    h.set_included_range(0, 1)
     assert h.get_total_frame_count() == 3
 
 
-def test_get_included_files_no_exclusions() -> None:
+def test_get_included_files_no_range_set() -> None:
     h = ImageStackHandler()
     h.files = ["/a.tif", "/b.tif"]
     assert h.get_included_files() == ["/a.tif", "/b.tif"]
 
 
-def test_get_included_files_with_exclusions() -> None:
+def test_get_included_files_with_range() -> None:
     h = ImageStackHandler()
     h.files = ["/a.tif", "/b.tif", "/c.tif"]
-    h.set_excluded_frames({0, 2})
+    h.set_included_range(1, 1)
     assert h.get_included_files() == ["/b.tif"]
 
 
-def test_load_stack_resets_excluded_frames(tmp_path: Path) -> None:
+def test_load_stack_resets_included_range(tmp_path: Path) -> None:
     (tmp_path / "f.tif").write_bytes(b"")
     h = ImageStackHandler()
-    h.set_excluded_frames({0, 1})
+    h.set_included_range(0, 1)
     h.load_image_stack(str(tmp_path))
-    assert h.get_excluded_frames() == set()
+    # After load, _included_end should be -1 (unset = all frames)
+    assert h._included_end == -1
 
 
-def test_get_all_frames_as_array_excludes_frames(tmp_path: Path) -> None:
+def test_get_all_frames_as_array_uses_range(tmp_path: Path) -> None:
     p0 = tmp_path / "0.tif"
     p1 = tmp_path / "1.tif"
     p2 = tmp_path / "2.tif"
@@ -136,21 +129,26 @@ def test_get_all_frames_as_array_excludes_frames(tmp_path: Path) -> None:
     tifffile.imwrite(p2, np.ones((2, 2), dtype=np.uint8) * 200)
     h = ImageStackHandler()
     h.load_image_stack([str(p0), str(p1), str(p2)])
-    h.set_excluded_frames({1})
+    h.set_included_range(0, 1)  # include frames 0 and 1 only
     stack = h.get_all_frames_as_array()
     assert stack is not None
     assert stack.shape == (2, 2, 2)
     np.testing.assert_array_equal(stack[0], np.zeros((2, 2), dtype=np.uint8))
-    np.testing.assert_array_equal(stack[1], np.ones((2, 2), dtype=np.uint8) * 200)
+    np.testing.assert_array_equal(stack[1], np.ones((2, 2), dtype=np.uint8) * 100)
 
 
-def test_get_all_frames_as_array_all_excluded(tmp_path: Path) -> None:
+def test_get_all_frames_as_array_empty_range(tmp_path: Path) -> None:
     p = tmp_path / "only.tif"
     tifffile.imwrite(p, np.zeros((2, 2), dtype=np.uint8))
     h = ImageStackHandler()
     h.load_image_stack([str(p)])
-    h.set_excluded_frames({0})
-    assert h.get_all_frames_as_array() is None
+    # set_included_range to valid range — can't make it empty with range API
+    # An empty result requires an out-of-bounds range which get_included_files clamps.
+    # Verify the normal single-frame case works correctly.
+    h.set_included_range(0, 0)
+    stack = h.get_all_frames_as_array()
+    assert stack is not None
+    assert stack.shape == (1, 2, 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -98,6 +98,11 @@ def test_get_total_frame_count() -> None:
     assert h.get_total_frame_count() == 3
 
 
+def test_get_included_files_empty_files_returns_empty() -> None:
+    h = ImageStackHandler()
+    assert h.get_included_files() == []
+
+
 def test_get_included_files_no_range_set() -> None:
     h = ImageStackHandler()
     h.files = ["/a.tif", "/b.tif"]
@@ -118,6 +123,26 @@ def test_load_stack_resets_included_range(tmp_path: Path) -> None:
     h.load_image_stack(str(tmp_path))
     # After load, _included_end should be -1 (unset = all frames)
     assert h._included_end == -1
+
+
+def test_load_stack_with_non_directory_string_returns_empty(tmp_path: Path) -> None:
+    # Passing a path that is not a directory takes the is_dir()=False branch
+    non_dir = str(tmp_path / "not_a_dir.tif")
+    h = ImageStackHandler()
+    result = h.load_image_stack(non_dir)
+    assert result == []
+
+
+def test_get_all_frames_as_array_rgb_frame(tmp_path: Path) -> None:
+    p = tmp_path / "rgb.tif"
+    rgb = np.zeros((4, 4, 3), dtype=np.uint8)
+    tifffile.imwrite(p, rgb)
+    h = ImageStackHandler()
+    h.load_image_stack([str(p)])
+    stack = h.get_all_frames_as_array()
+    # RGB frame should be collapsed to 2D (mean across channels)
+    assert stack is not None
+    assert stack.ndim == 3  # (1 frame, height, width)
 
 
 def test_get_all_frames_as_array_uses_range(tmp_path: Path) -> None:

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -1,9 +1,8 @@
-"""Tests for ImageViewer frame-culling features."""
+"""Tests for ImageViewer range-based frame culling."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -22,7 +21,6 @@ def app():
 
 
 def _make_stack(tmp_path: Path, n: int = 5) -> list[str]:
-    """Write *n* tiny 4x4 TIFF files and return their paths."""
     paths = []
     for i in range(n):
         p = tmp_path / f"frame_{i:03d}.tif"
@@ -33,7 +31,6 @@ def _make_stack(tmp_path: Path, n: int = 5) -> list[str]:
 
 @pytest.fixture
 def viewer(app, tmp_path):
-    """Create an ImageViewer loaded with a 5-frame stack."""
     files = _make_stack(tmp_path, 5)
     handler = ImageStackHandler()
     v = ImageViewer(handler)
@@ -45,8 +42,10 @@ def viewer(app, tmp_path):
 
 
 class TestCullingInitialState:
-    def test_excluded_frames_empty_on_init(self, viewer) -> None:
-        assert viewer.get_excluded_frames() == set()
+    def test_range_covers_all_frames_on_load(self, viewer) -> None:
+        start, end = viewer.get_cull_range()
+        assert start == 0
+        assert end == 4
 
     def test_filter_excluded_off_by_default(self, viewer) -> None:
         assert viewer._filter_excluded is False
@@ -54,70 +53,30 @@ class TestCullingInitialState:
     def test_cull_panel_hidden_by_default(self, viewer) -> None:
         assert viewer.cull_controls_panel.isVisible() is False
 
-    def test_cull_count_label_zero(self, viewer) -> None:
-        assert "0" in viewer._cull_count_label.text()
+
+# ── get / set cull range ─────────────────────────────────────────────────
 
 
-# ── get / set excluded frames ────────────────────────────────────────────
-
-
-class TestGetSetExcludedFrames:
+class TestGetSetCullRange:
     def test_set_and_get_round_trip(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
-        assert viewer.get_excluded_frames() == {1, 3}
+        viewer.set_cull_range(1, 3)
+        assert viewer.get_cull_range() == (1, 3)
 
-    def test_get_returns_copy(self, viewer) -> None:
-        viewer.set_excluded_frames({0})
-        result = viewer.get_excluded_frames()
-        result.add(99)
-        assert 99 not in viewer.get_excluded_frames()
+    def test_set_clamps_to_valid_range(self, viewer) -> None:
+        viewer.set_cull_range(-5, 100)
+        start, end = viewer.get_cull_range()
+        assert start == 0
+        assert end == 4
 
-    def test_set_updates_cull_button_text(self, viewer) -> None:
-        viewer.set_excluded_frames({0})
-        viewer.index = 0
-        viewer._refresh_cull_button()
-        assert "Include" in viewer._cull_toggle_btn.text()
+    def test_set_updates_range_slider(self, viewer) -> None:
+        viewer.set_cull_range(2, 4)
+        assert viewer._range_slider.get_start() == 2
+        assert viewer._range_slider.get_end() == 4
 
-    def test_set_updates_count_label(self, viewer) -> None:
-        viewer.set_excluded_frames({0, 2, 4})
-        assert "3" in viewer._cull_count_label.text()
-
-    def test_count_label_singular(self, viewer) -> None:
-        viewer.set_excluded_frames({2})
-        assert "1 frame excluded" in viewer._cull_count_label.text()
-
-
-# ── Cull toggle ──────────────────────────────────────────────────────────
-
-
-class TestCullToggle:
-    def test_toggle_excludes_current_frame(self, viewer) -> None:
-        viewer.index = 2
-        viewer._on_cull_toggle()
-        assert 2 in viewer.get_excluded_frames()
-
-    def test_toggle_re_includes_excluded_frame(self, viewer) -> None:
-        viewer.index = 2
-        viewer._on_cull_toggle()  # exclude
-        viewer._on_cull_toggle()  # re-include
-        assert 2 not in viewer.get_excluded_frames()
-
-    def test_toggle_emits_signal(self, viewer) -> None:
-        spy = Mock()
-        viewer.frameCullingChanged.connect(spy)
-        viewer.index = 1
-        viewer._on_cull_toggle()
-        spy.assert_called_once()
-        emitted = spy.call_args[0][0]
-        assert isinstance(emitted, set)
-        assert 1 in emitted
-
-    def test_toggle_updates_button_label(self, viewer) -> None:
-        viewer.index = 0
-        viewer._on_cull_toggle()
-        assert "Include" in viewer._cull_toggle_btn.text()
-        viewer._on_cull_toggle()
-        assert "Exclude" in viewer._cull_toggle_btn.text()
+    def test_range_start_cannot_exceed_end(self, viewer) -> None:
+        viewer.set_cull_range(3, 1)
+        start, end = viewer.get_cull_range()
+        assert start <= end
 
 
 # ── Visible indices / navigation with filter ─────────────────────────────
@@ -127,25 +86,29 @@ class TestVisibleIndices:
     def test_all_visible_by_default(self, viewer) -> None:
         assert viewer._visible_indices == [0, 1, 2, 3, 4]
 
-    def test_filter_off_shows_all_even_with_exclusions(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
+    def test_filter_off_shows_all_even_with_range(self, viewer) -> None:
+        viewer.set_cull_range(1, 3)
         assert viewer._visible_indices == [0, 1, 2, 3, 4]
 
-    def test_filter_on_hides_excluded(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
+    def test_filter_on_shows_only_included_range(self, viewer) -> None:
+        viewer.set_cull_range(1, 3)
         viewer._filter_excluded = True
-        assert viewer._visible_indices == [0, 2, 4]
+        assert viewer._visible_indices == [1, 2, 3]
+
+    def test_full_range_filter_on_shows_all(self, viewer) -> None:
+        viewer._filter_excluded = True
+        assert viewer._visible_indices == [0, 1, 2, 3, 4]
 
 
 class TestSetFilterExcluded:
     def test_enables_filtering(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
         assert viewer._filter_excluded is True
-        assert viewer._visible_indices == [0, 2, 4]
+        assert viewer._visible_indices == [1, 2, 3]
 
     def test_disables_filtering(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
         viewer.set_filter_excluded(False)
         assert viewer._visible_indices == [0, 1, 2, 3, 4]
@@ -155,43 +118,43 @@ class TestSetFilterExcluded:
         assert viewer._filter_excluded is False
 
     def test_snaps_to_visible_frame(self, viewer) -> None:
-        viewer.index = 1
-        viewer.set_excluded_frames({1})
+        viewer.index = 0
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
         assert viewer.index in viewer._visible_indices
 
     def test_slider_range_matches_visible(self, viewer) -> None:
-        viewer.set_excluded_frames({0, 2, 4})
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
-        assert viewer.slider.maximum() == 1  # 2 visible frames → slider 0..1
+        assert viewer.slider.maximum() == 2  # 3 visible frames → slider 0..2
 
 
 class TestNavigationWithFilter:
-    def test_next_image_skips_excluded(self, viewer) -> None:
-        viewer.set_excluded_frames({1})
+    def test_next_image_stays_in_range(self, viewer) -> None:
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
-        viewer.index = 0
+        viewer.index = 1
         viewer.slider.setValue(0)
         viewer.next_image()
         assert viewer.index == 2
 
-    def test_prev_image_skips_excluded(self, viewer) -> None:
-        viewer.set_excluded_frames({1})
+    def test_prev_image_stays_in_range(self, viewer) -> None:
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
-        viewer.index = 2
-        viewer.slider.setValue(1)
+        viewer.index = 3
+        viewer.slider.setValue(2)
         viewer.prev_image()
-        assert viewer.index == 0
+        assert viewer.index == 2
 
     def test_on_slider_maps_to_visible_index(self, viewer) -> None:
-        viewer.set_excluded_frames({1, 3})
+        viewer.set_cull_range(2, 4)
         viewer.set_filter_excluded(True)
-        # visible = [0, 2, 4], slider pos 2 → raw index 4
+        # visible = [2, 3, 4], slider pos 2 → raw index 4
         viewer._on_slider(2)
         assert viewer.index == 4
 
     def test_next_at_end_stays(self, viewer) -> None:
-        viewer.set_excluded_frames({3, 4})
+        viewer.set_cull_range(0, 2)
         viewer.set_filter_excluded(True)
         viewer.index = 2
         viewer.slider.setValue(2)
@@ -206,13 +169,29 @@ class TestNavigationWithFilter:
         assert viewer.index == 0
 
 
+# ── Range slider signal ──────────────────────────────────────────────────
+
+
+class TestRangeSliderSignal:
+    def test_range_changed_emits_frameCullingChanged(self, viewer) -> None:
+        received = []
+        viewer.frameCullingChanged.connect(lambda s, e: received.append((s, e)))
+        viewer._range_slider.range_changed.emit(1, 3)
+        assert received == [(1, 3)]
+        assert viewer.get_cull_range() == (1, 3)
+
+    def test_frame_preview_jumps_viewer(self, viewer) -> None:
+        viewer._range_slider.frame_preview_requested.emit(3)
+        assert viewer.index == 3
+
+
 # ── Reset ────────────────────────────────────────────────────────────────
 
 
-class TestResetClearsExclusions:
-    def test_reset_clears_excluded_frames(self, viewer) -> None:
-        viewer.set_excluded_frames({0, 1, 2})
+class TestResetClearsCullRange:
+    def test_reset_resets_cull_end_to_unset(self, viewer) -> None:
+        viewer.set_cull_range(1, 3)
         viewer.set_filter_excluded(True)
         viewer.reset()
-        assert viewer.get_excluded_frames() == set()
+        assert viewer._cull_end == -1
         assert viewer._filter_excluded is False

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -101,6 +101,23 @@ class TestVisibleIndices:
         assert viewer._visible_indices == [0, 1, 2, 3, 4]
 
 
+class TestVisibleIndicesEmptyStack:
+    def test_empty_stack_filter_off_returns_empty(self, app) -> None:
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        assert v._visible_indices == []
+
+    def test_empty_stack_filter_on_returns_empty(self, app) -> None:
+        # Regression: if _cull_end was set from a previous stack and filter is
+        # enabled but total is now 0, must still return [] not [0].
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        v._cull_start = 1
+        v._cull_end = 3
+        v._filter_excluded = True
+        assert v._visible_indices == []
+
+
 class TestSetFilterExcluded:
     def test_enables_filtering(self, viewer) -> None:
         viewer.set_cull_range(1, 3)

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import Mock
 
 import numpy as np
 import pytest

--- a/tests/test_image_viewer_culling.py
+++ b/tests/test_image_viewer_culling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -195,3 +196,53 @@ class TestResetClearsCullRange:
         viewer.reset()
         assert viewer._cull_end == -1
         assert viewer._filter_excluded is False
+
+
+# ── set_stack edge cases ─────────────────────────────────────────────────
+
+
+class TestSetStackEdgeCases:
+    def test_set_stack_empty_list_sets_cull_end_negative(self, app) -> None:
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        v.set_stack([])
+        assert v._cull_end == -1
+
+    def test_set_stack_emits_stackLoaded_for_list(self, app, tmp_path) -> None:
+        files = _make_stack(tmp_path, 2)
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        received = []
+        v.stackLoaded.connect(received.append)
+        v.set_stack(files)
+        assert len(received) == 1
+
+    def test_set_stack_emits_stackLoaded_for_directory(self, app, tmp_path) -> None:
+        _make_stack(tmp_path, 2)
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        received = []
+        v.stackLoaded.connect(received.append)
+        v.set_stack(str(tmp_path))
+        assert len(received) == 1
+
+    def test_set_stack_empty_list_no_stackLoaded(self, app) -> None:
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        received = []
+        v.stackLoaded.connect(received.append)
+        v.set_stack([])
+        assert received == []
+
+
+# ── set_cull_range with no stack ─────────────────────────────────────────
+
+
+class TestSetCullRangeNoStack:
+    def test_set_cull_range_no_stack_stores_values(self, app) -> None:
+        handler = ImageStackHandler()
+        v = ImageViewer(handler)
+        # No stack loaded: total == 0, else branch is taken
+        v.set_cull_range(2, 7)
+        assert v._cull_start == 2
+        assert v._cull_end == 7

--- a/tests/test_main_window_culling.py
+++ b/tests/test_main_window_culling.py
@@ -111,6 +111,14 @@ class TestOnFrameCullingChanged:
             main_window._on_frame_culling_changed(0, 9)
             mock_save.assert_not_called()
 
+    def test_updates_existing_culling_dict(self, main_window) -> None:
+        # "culling" already present — should update keys, not reinitialize
+        main_window.experiment.settings["culling"] = {"start_frame": 0, "end_frame": 5}
+        main_window._on_frame_culling_changed(1, 8)
+        culling = main_window.experiment.settings["culling"]
+        assert culling["start_frame"] == 1
+        assert culling["end_frame"] == 8
+
     def test_resets_downstream_when_cull_already_completed(self, main_window) -> None:
         wm = main_window.workflow_manager
         wm.completed_steps.add(WorkflowStep.CULL_FRAMES)

--- a/tests/test_main_window_culling.py
+++ b/tests/test_main_window_culling.py
@@ -20,7 +20,6 @@ def app():
 
 
 def _make_main_window(app, experiment=None):
-    """Build a MainWindow with lightweight mocks, similar to existing test fixtures."""
     exp = experiment or Experiment(name="Culling Test")
     exp.settings = exp.settings if exp.settings else {}
 
@@ -33,7 +32,7 @@ def _make_main_window(app, experiment=None):
     mock_viewer.get_current_roi = Mock(return_value=None)
     mock_viewer.get_exposure = Mock(return_value=0)
     mock_viewer.get_contrast = Mock(return_value=0)
-    mock_viewer.set_excluded_frames = Mock()
+    mock_viewer.set_cull_range = Mock()
     mock_viewer.set_filter_excluded = Mock()
     mock_viewer.stackLoaded = Mock()
     mock_viewer.stackLoaded.connect = Mock()
@@ -57,8 +56,8 @@ def _make_main_window(app, experiment=None):
     mock_stack_handler.files = []
     mock_stack_handler.associate_with_experiment = Mock()
     mock_stack_handler.get_total_frame_count = Mock(return_value=10)
-    mock_stack_handler.set_excluded_frames = Mock()
-    mock_stack_handler.get_excluded_frames = Mock(return_value=set())
+    mock_stack_handler.set_included_range = Mock()
+    mock_stack_handler.get_included_range = Mock(return_value=(0, 9))
 
     with (
         patch("ui.main_window.ImageViewer", return_value=mock_viewer),
@@ -80,35 +79,36 @@ def main_window(app):
 
 
 class TestOnFrameCullingChanged:
-    def test_persists_excluded_frames_to_settings(self, main_window) -> None:
-        main_window._on_frame_culling_changed({2, 5})
+    def test_persists_range_to_settings(self, main_window) -> None:
+        main_window._on_frame_culling_changed(2, 7)
         culling = main_window.experiment.settings["culling"]
-        assert culling["excluded_frames"] == [2, 5]
+        assert culling["start_frame"] == 2
+        assert culling["end_frame"] == 7
 
-    def test_syncs_exclusions_to_stack_handler(self, main_window) -> None:
-        main_window._on_frame_culling_changed({0, 3})
-        main_window.stack_handler.set_excluded_frames.assert_called_with({0, 3})
+    def test_syncs_range_to_stack_handler(self, main_window) -> None:
+        main_window._on_frame_culling_changed(1, 8)
+        main_window.stack_handler.set_included_range.assert_called_with(1, 8)
 
-    def test_marks_cull_step_ready_when_not_all_excluded(self, main_window) -> None:
+    def test_marks_cull_step_ready_with_valid_range(self, main_window) -> None:
         main_window.stack_handler.get_total_frame_count.return_value = 10
-        main_window._on_frame_culling_changed({1})
+        main_window._on_frame_culling_changed(0, 9)
         assert main_window.workflow_manager.is_step_ready(WorkflowStep.CULL_FRAMES)
 
-    def test_revokes_readiness_when_all_excluded(self, main_window) -> None:
-        main_window.stack_handler.get_total_frame_count.return_value = 3
-        main_window._on_frame_culling_changed({0, 1, 2})
+    def test_revokes_readiness_when_start_exceeds_end(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 10
+        main_window._on_frame_culling_changed(5, 3)
         assert not main_window.workflow_manager.is_step_ready(WorkflowStep.CULL_FRAMES)
 
     def test_saves_experiment_when_path_known(self, main_window) -> None:
         main_window.current_experiment_path = "/tmp/test.nexp"
         with patch.object(main_window.manager, "save_experiment") as mock_save:
-            main_window._on_frame_culling_changed({1})
+            main_window._on_frame_culling_changed(0, 9)
             mock_save.assert_called_once()
 
     def test_does_not_save_when_path_unknown(self, main_window) -> None:
         main_window.current_experiment_path = None
         with patch.object(main_window.manager, "save_experiment") as mock_save:
-            main_window._on_frame_culling_changed({1})
+            main_window._on_frame_culling_changed(0, 9)
             mock_save.assert_not_called()
 
     def test_resets_downstream_when_cull_already_completed(self, main_window) -> None:
@@ -116,7 +116,7 @@ class TestOnFrameCullingChanged:
         wm.completed_steps.add(WorkflowStep.CULL_FRAMES)
         wm.completed_steps.add(WorkflowStep.ALIGN_IMAGES)
         main_window.stack_handler.get_total_frame_count.return_value = 10
-        main_window._on_frame_culling_changed({2})
+        main_window._on_frame_culling_changed(1, 8)
         assert WorkflowStep.ALIGN_IMAGES not in wm.completed_steps
 
 
@@ -124,28 +124,35 @@ class TestOnFrameCullingChanged:
 
 
 class TestRestoreCullingState:
-    def test_restores_valid_entries(self, main_window) -> None:
-        main_window.experiment.settings["culling"] = {"excluded_frames": [1, 3, 7]}
+    def test_restores_valid_range(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 10
+        main_window.experiment.settings["culling"] = {"start_frame": 2, "end_frame": 7}
         main_window._restore_culling_state()
-        main_window.stack_handler.set_excluded_frames.assert_called_with({1, 3, 7})
-        main_window.viewer.set_excluded_frames.assert_called_with({1, 3, 7})
+        main_window.stack_handler.set_included_range.assert_called_with(2, 7)
+        main_window.viewer.set_cull_range.assert_called_with(2, 7)
 
-    def test_skips_malformed_entries(self, main_window) -> None:
-        main_window.experiment.settings["culling"] = {"excluded_frames": [0, "bad", None, 4, "also_bad"]}
-        main_window._restore_culling_state()
-        main_window.stack_handler.set_excluded_frames.assert_called_with({0, 4})
-
-    def test_handles_empty_culling_section(self, main_window) -> None:
+    def test_defaults_to_full_range_when_missing(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 5
         main_window.experiment.settings = {}
         main_window._restore_culling_state()
-        main_window.stack_handler.set_excluded_frames.assert_called_with(set())
+        main_window.stack_handler.set_included_range.assert_called_with(0, 4)
 
-    def test_handles_missing_excluded_frames_key(self, main_window) -> None:
+    def test_handles_empty_culling_section(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 5
         main_window.experiment.settings["culling"] = {}
         main_window._restore_culling_state()
-        main_window.stack_handler.set_excluded_frames.assert_called_with(set())
+        main_window.stack_handler.set_included_range.assert_called_with(0, 4)
 
-    def test_coerces_string_ints(self, main_window) -> None:
-        main_window.experiment.settings["culling"] = {"excluded_frames": ["2", "5"]}
+    def test_clamps_out_of_bounds_values(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 5
+        main_window.experiment.settings["culling"] = {"start_frame": -1, "end_frame": 100}
         main_window._restore_culling_state()
-        main_window.stack_handler.set_excluded_frames.assert_called_with({2, 5})
+        start, end = main_window.stack_handler.set_included_range.call_args[0]
+        assert start >= 0
+        assert end <= 4
+
+    def test_handles_malformed_values(self, main_window) -> None:
+        main_window.stack_handler.get_total_frame_count.return_value = 5
+        main_window.experiment.settings["culling"] = {"start_frame": "bad", "end_frame": None}
+        main_window._restore_culling_state()
+        main_window.stack_handler.set_included_range.assert_called_with(0, 4)

--- a/tests/test_range_slider.py
+++ b/tests/test_range_slider.py
@@ -1,0 +1,486 @@
+"""Tests for DualHandleRangeSlider."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QMouseEvent, QPaintEvent, QRegion
+from PySide6.QtWidgets import QApplication
+
+from ui.range_slider import DualHandleRangeSlider
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_slider(app, total: int = 10, width: int = 300, height: int = 80) -> DualHandleRangeSlider:
+    s = DualHandleRangeSlider()
+    s.resize(width, height)
+    s.set_total(total)
+    return s
+
+
+def _press(slider: DualHandleRangeSlider, x: float, y: float) -> None:
+    ev = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress,
+        QPointF(x, y),
+        QPointF(x, y),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    slider.mousePressEvent(ev)
+
+
+def _move(slider: DualHandleRangeSlider, x: float, y: float) -> None:
+    ev = QMouseEvent(
+        QMouseEvent.Type.MouseMove,
+        QPointF(x, y),
+        QPointF(x, y),
+        Qt.MouseButton.NoButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    slider.mouseMoveEvent(ev)
+
+
+def _release(slider: DualHandleRangeSlider, x: float, y: float) -> None:
+    ev = QMouseEvent(
+        QMouseEvent.Type.MouseButtonRelease,
+        QPointF(x, y),
+        QPointF(x, y),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    slider.mouseReleaseEvent(ev)
+
+
+# ── Initialization ────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_default_total_is_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        assert s._total == 0
+
+    def test_default_start_end_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        assert s._start == 0
+        assert s._end == 0
+
+    def test_default_dragging_none(self, app) -> None:
+        s = DualHandleRangeSlider()
+        assert s._dragging is None
+
+    def test_minimum_height(self, app) -> None:
+        s = DualHandleRangeSlider()
+        assert s.minimumHeight() == 60
+
+
+# ── set_total ─────────────────────────────────────────────────────────────
+
+
+class TestSetTotal:
+    def test_sets_total(self, app) -> None:
+        s = _make_slider(app, total=5)
+        assert s._total == 5
+
+    def test_resets_start_to_zero(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(3, 7)
+        s.set_total(10)
+        assert s._start == 0
+
+    def test_sets_end_to_last_frame(self, app) -> None:
+        s = _make_slider(app, total=10)
+        assert s._end == 9
+
+    def test_negative_total_clamped_to_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.set_total(-5)
+        assert s._total == 0
+
+    def test_zero_total_end_stays_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.set_total(0)
+        assert s._end == 0
+
+    def test_single_frame_total(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.set_total(1)
+        assert s._total == 1
+        assert s._start == 0
+        assert s._end == 0
+
+
+# ── set_values ────────────────────────────────────────────────────────────
+
+
+class TestSetValues:
+    def test_valid_range(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(2, 7)
+        assert s.get_start() == 2
+        assert s.get_end() == 7
+
+    def test_noop_when_total_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.set_values(2, 7)
+        assert s._start == 0
+        assert s._end == 0
+
+    def test_start_clamped_to_zero(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(-5, 8)
+        assert s.get_start() == 0
+
+    def test_end_clamped_to_last_frame(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(0, 100)
+        assert s.get_end() == 9
+
+    def test_start_cannot_exceed_end(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(8, 2)
+        # start is clamped, then end is max(start, ...)
+        assert s.get_start() <= s.get_end()
+
+    def test_get_start_get_end(self, app) -> None:
+        s = _make_slider(app, total=10)
+        s.set_values(1, 6)
+        assert s.get_start() == 1
+        assert s.get_end() == 6
+
+
+# ── Geometry helpers ──────────────────────────────────────────────────────
+
+
+class TestGeometry:
+    def test_usable_w_returns_width_minus_padding(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.resize(300, 80)
+        assert s._usable_w() == 300 - 2 * DualHandleRangeSlider._PAD
+
+    def test_usable_w_minimum_one(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.resize(0, 80)
+        assert s._usable_w() >= 1
+
+    def test_frame_to_x_first_frame(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._frame_to_x(0) == s._PAD
+
+    def test_frame_to_x_last_frame(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._frame_to_x(9) == s._PAD + s._usable_w()
+
+    def test_frame_to_x_single_frame(self, app) -> None:
+        s = _make_slider(app, total=1, width=300)
+        assert s._frame_to_x(0) == s._PAD + s._usable_w() // 2
+
+    def test_x_to_frame_left_edge(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._x_to_frame(s._PAD) == 0
+
+    def test_x_to_frame_right_edge(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._x_to_frame(s._PAD + s._usable_w()) == 9
+
+    def test_x_to_frame_single_frame_always_zero(self, app) -> None:
+        s = _make_slider(app, total=1, width=300)
+        assert s._x_to_frame(150) == 0
+
+    def test_x_to_frame_clamps_below_zero(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._x_to_frame(-1000) == 0
+
+    def test_x_to_frame_clamps_above_max(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        assert s._x_to_frame(10000) == 9
+
+    def test_track_y(self, app) -> None:
+        s = DualHandleRangeSlider()
+        expected = s._LABEL_H + s._HANDLE_RADIUS + 4
+        assert s._track_y() == expected
+
+    def test_frame_to_x_x_to_frame_round_trip(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        for frame in range(10):
+            x = s._frame_to_x(frame)
+            assert s._x_to_frame(x) == frame
+
+
+# ── paintEvent ────────────────────────────────────────────────────────────
+
+
+class TestPaintEvent:
+    def test_no_paint_when_total_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.resize(300, 80)
+        # Should return immediately without error
+        ev = QPaintEvent(QRegion(s.rect()))
+        s.paintEvent(ev)
+
+    def test_paint_does_not_crash_full_range(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.show()
+        QApplication.processEvents()
+        s.hide()
+
+    def test_paint_does_not_crash_partial_range(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(2, 7)
+        s.show()
+        QApplication.processEvents()
+        s.hide()
+
+    def test_paint_does_not_crash_start_equals_end(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(5, 5)
+        s.show()
+        QApplication.processEvents()
+        s.hide()
+
+    def test_paint_does_not_crash_single_frame(self, app) -> None:
+        s = _make_slider(app, total=1, width=300)
+        s.show()
+        QApplication.processEvents()
+        s.hide()
+
+
+# ── mousePressEvent ───────────────────────────────────────────────────────
+
+
+class TestMousePressEvent:
+    def test_no_drag_when_total_zero(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.resize(300, 80)
+        _press(s, 150, 33)
+        assert s._dragging is None
+
+    def test_press_on_start_handle_selects_start(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_start = s._frame_to_x(0)
+        _press(s, x_start, s._track_y())
+        assert s._dragging == "start"
+
+    def test_press_on_end_handle_selects_end(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_end = s._frame_to_x(9)
+        _press(s, x_end, s._track_y())
+        assert s._dragging == "end"
+
+    def test_press_far_from_handles_no_drag(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(0, 9)
+        # Click in the middle track area, far from both handles
+        _press(s, s._frame_to_x(4), s._track_y())
+        # Neither handle is at frame 4 (start=0, end=9), so no drag
+        assert s._dragging is None
+
+    def test_prefer_start_when_handles_equidistant(self, app) -> None:
+        # When handles are at the same position, start is preferred
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(5, 5)
+        x = s._frame_to_x(5)
+        _press(s, x, s._track_y())
+        assert s._dragging == "start"
+
+
+# ── mouseMoveEvent ────────────────────────────────────────────────────────
+
+
+class TestMouseMoveEvent:
+    def test_no_move_when_not_dragging(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        _move(s, s._frame_to_x(5), s._track_y())
+        assert received == []
+
+    def test_no_move_when_total_zero_while_dragging(self, app) -> None:
+        s = DualHandleRangeSlider()
+        s.resize(300, 80)
+        s._dragging = "start"
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        _move(s, 150, 33)
+        assert received == []
+
+    def test_drag_start_emits_preview(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_start = s._frame_to_x(0)
+        _press(s, x_start, s._track_y())
+
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        x_mid = s._frame_to_x(4)
+        _move(s, x_mid, s._track_y())
+
+        assert 4 in received
+        assert s._start == 4
+
+    def test_drag_end_emits_preview(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_end = s._frame_to_x(9)
+        _press(s, x_end, s._track_y())
+
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        x_new = s._frame_to_x(6)
+        _move(s, x_new, s._track_y())
+
+        assert 6 in received
+        assert s._end == 6
+
+    def test_start_cannot_exceed_end(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(0, 5)
+        x_start = s._frame_to_x(0)
+        _press(s, x_start, s._track_y())
+        # Try dragging start past end
+        _move(s, s._frame_to_x(8), s._track_y())
+        assert s._start <= s._end
+
+    def test_end_cannot_go_below_start(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(5, 9)
+        x_end = s._frame_to_x(9)
+        _press(s, x_end, s._track_y())
+        # Try dragging end before start
+        _move(s, s._frame_to_x(2), s._track_y())
+        assert s._end >= s._start
+
+    def test_no_signal_when_start_frame_unchanged(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_start = s._frame_to_x(0)
+        _press(s, x_start, s._track_y())
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        # Move to same position — frame doesn't change
+        _move(s, x_start, s._track_y())
+        assert received == []
+
+    def test_no_signal_when_end_frame_unchanged(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        x_end = s._frame_to_x(9)
+        _press(s, x_end, s._track_y())
+        received = []
+        s.frame_preview_requested.connect(received.append)
+        # Move to same position — end frame doesn't change
+        _move(s, x_end, s._track_y())
+        assert received == []
+
+
+# ── mouseReleaseEvent ─────────────────────────────────────────────────────
+
+
+class TestMouseReleaseEvent:
+    def test_release_without_drag_does_not_emit(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        received = []
+        s.range_changed.connect(lambda a, b: received.append((a, b)))
+        _release(s, 150, 33)
+        assert received == []
+
+    def test_release_after_start_drag_emits_range(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        received = []
+        s.range_changed.connect(lambda a, b: received.append((a, b)))
+
+        _press(s, s._frame_to_x(0), s._track_y())
+        _move(s, s._frame_to_x(3), s._track_y())
+        _release(s, s._frame_to_x(3), s._track_y())
+
+        assert len(received) == 1
+        assert received[0] == (3, 9)
+
+    def test_release_after_end_drag_emits_range(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        received = []
+        s.range_changed.connect(lambda a, b: received.append((a, b)))
+
+        _press(s, s._frame_to_x(9), s._track_y())
+        _move(s, s._frame_to_x(6), s._track_y())
+        _release(s, s._frame_to_x(6), s._track_y())
+
+        assert len(received) == 1
+        assert received[0] == (0, 6)
+
+    def test_release_clears_dragging(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        _press(s, s._frame_to_x(0), s._track_y())
+        assert s._dragging == "start"
+        _release(s, s._frame_to_x(0), s._track_y())
+        assert s._dragging is None
+
+    def test_range_changed_emits_correct_int_types(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        received = []
+        s.range_changed.connect(lambda a, b: received.append((type(a), type(b))))
+        _press(s, s._frame_to_x(0), s._track_y())
+        _release(s, s._frame_to_x(0), s._track_y())
+        assert received == [(int, int)]
+
+
+# ── Label text ────────────────────────────────────────────────────────────
+
+
+class TestLabelText:
+    def test_label_uses_one_indexed_frames(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        s.set_values(0, 9)
+        # Labels are "Frame N" where N = 0-indexed + 1
+        # Verify via internal state since rendering is visual
+        assert s._start + 1 == 1
+        assert s._end + 1 == 10
+
+    def test_label_updates_during_drag(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        _press(s, s._frame_to_x(0), s._track_y())
+        _move(s, s._frame_to_x(4), s._track_y())
+        # After dragging to frame 4, label should show "Frame 5"
+        assert s._start + 1 == 5
+
+    def test_end_label_updates_during_drag(self, app) -> None:
+        s = _make_slider(app, total=10, width=300)
+        _press(s, s._frame_to_x(9), s._track_y())
+        _move(s, s._frame_to_x(6), s._track_y())
+        assert s._end + 1 == 7
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_single_frame_widget_renders(self, app) -> None:
+        s = _make_slider(app, total=1, width=300)
+        assert s._start == 0
+        assert s._end == 0
+        s.show()
+        QApplication.processEvents()
+        s.hide()
+
+    def test_full_drag_sequence(self, app) -> None:
+        s = _make_slider(app, total=20, width=400)
+        preview_frames = []
+        range_calls = []
+        s.frame_preview_requested.connect(preview_frames.append)
+        s.range_changed.connect(lambda a, b: range_calls.append((a, b)))
+
+        # Drag start from frame 0 to frame 5
+        _press(s, s._frame_to_x(0), s._track_y())
+        _move(s, s._frame_to_x(5), s._track_y())
+        _release(s, s._frame_to_x(5), s._track_y())
+
+        assert s.get_start() == 5
+        assert s.get_end() == 19
+        assert 5 in preview_frames
+        assert (5, 19) in range_calls

--- a/tests/test_range_slider.py
+++ b/tests/test_range_slider.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
-
 import pytest
 from PySide6.QtCore import QPointF, Qt
 from PySide6.QtGui import QMouseEvent, QPaintEvent, QRegion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual-handle range slider for selecting an inclusive frame range with live preview while dragging.
  * Range controls emit preview and final range change events to update the viewer immediately.

* **Refactor**
  * Frame culling now uses an inclusive start/end range (slider-driven) instead of per-frame exclusions; filtering and navigation respect the configured range.
  * Reset/stack load initialize and synchronize the range state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->