### PR TITLE
Feature/public user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ source = ["src"]
 branch = true
 omit = [
     "src/__init__.py",
-    "src/main.py",
 ]
 
 [tool.coverage.report]
@@ -69,5 +68,5 @@ exclude_lines = [
 ]
 show_missing = true
 skip_covered = true
-fail_under = 0
+fail_under = 80
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = ["src"]
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-exclude = [".venv", "build", "dist"]
+exclude = [".venv", ".claude", "build", "dist"]
 
 [tool.ruff.lint]
 select = ["F", "E", "I", "UP"]

--- a/src/core/experiment_manager.py
+++ b/src/core/experiment_manager.py
@@ -10,6 +10,16 @@ from typing import Any
 
 import numpy as np
 
+
+def _repo_root() -> Path:
+    # This file lives at src/core/experiment_manager.py
+    return Path(__file__).resolve().parents[2]
+
+
+def _public_experiments_dir() -> Path:
+    return _repo_root() / "users" / "Public" / "experiments"
+
+
 CONFIG_DIR = Path.home() / ".neurolight"
 try:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -332,6 +342,16 @@ class ExperimentManager:
     def save_experiment(self, experiment: Experiment, file_path: str | None = None) -> bool:
         if not file_path:
             raise ValueError("file_path is required for saving experiment")
+        # Backstop: the Public User's copies are read-only and must never be modified.
+        # (UI code should prevent this, but this ensures correctness if a save is attempted anyway.)
+        try:
+            target = Path(file_path).resolve()
+            pub_dir = _public_experiments_dir().resolve()
+            if pub_dir in target.parents:
+                return False
+        except Exception:
+            # If path resolution fails, fall through to best-effort save behavior.
+            pass
         experiment.update_modified_date()
         payload = experiment.to_json()
         os.makedirs(os.path.dirname(file_path), exist_ok=True)

--- a/src/core/experiment_manager.py
+++ b/src/core/experiment_manager.py
@@ -52,6 +52,8 @@ class Experiment:
     # Coordinates are in original image pixels, ensuring ROIs stay fixed to
     # the image region regardless of window size or scaling.
     rois: dict[str, Any] = field(default_factory=lambda: {"roi_1": None, "roi_2": None})
+    # When True the experiment is visible to the Public User (read-only viewer).
+    is_public: bool = False
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -80,6 +82,8 @@ class Experiment:
                 },
                 # Backward compat: write roi_1 as legacy "roi" so older versions can read it
                 "roi": self.rois.get("roi_1"),
+                # Public-visibility flag (False = private, True = viewable by Public User)
+                "is_public": self.is_public,
                 # Save neuron detection data if available
                 "neuron_detection": self._serialize_neuron_detection(),
             },
@@ -122,6 +126,7 @@ class Experiment:
             analysis_results=exp.get("analysis", {}).get("results", {}),
             settings=exp.get("settings", {}),
             rois=rois,
+            is_public=bool(exp.get("is_public", False)),
         )
         # Load neuron detection data if available
         neuron_detection = exp.get("neuron_detection")

--- a/src/core/image_processor.py
+++ b/src/core/image_processor.py
@@ -667,7 +667,9 @@ class ImageProcessor:
         present_indices = np.flatnonzero(absent_frame_mask)
 
         if len(present_indices) > 1:
-            correlation_matrix = np.corrcoef(neuron_trajectories[present_indices])
+            # Constant or near-constant trajectories yield zero std; corrcoef divides by std → NaNs + RuntimeWarning.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                correlation_matrix = np.corrcoef(neuron_trajectories[present_indices])
 
             mean_correlations = np.zeros(len(present_indices), dtype=np.float32)
             for i in range(len(present_indices)):

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ if get_enable_alignment_multiprocessing() or os.environ.get("NEUROLIGHT_ENABLE_M
 
 from ui.app_settings import get_theme
 from ui.main_window import MainWindow
+from ui.public_user_dialog import ensure_public_user_exists, is_public_user, sync_public_experiments
 from ui.startup_dialog import StartupDialog
 from ui.styles import get_stylesheet
 from ui.user_selection_dialog import UserSelectionDialog
@@ -43,10 +44,19 @@ def main() -> int:
     theme = get_theme()
     app.setStyleSheet(get_stylesheet(theme))
 
+    # Ensure the permanent Public User account directory exists before the
+    # user-selection screen is shown (so it always appears in the user list).
+    ensure_public_user_exists()
+
     # User selection first, then experiment manager
     user_dialog = UserSelectionDialog()
     if user_dialog.exec() != QDialog.Accepted:
         return 0
+
+    # When the Public User logs in, rebuild their experiment list by scanning
+    # all other users' folders for experiments marked is_public=True.
+    if is_public_user(user_dialog.selected_user_experiments_dir.parent.name):
+        sync_public_experiments()
 
     startup = StartupDialog(user_dialog.selected_user_experiments_dir)
     result = startup.exec()

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication, QDialog
 
@@ -38,6 +38,10 @@ else:
 
 
 def main() -> int:
+    # macOS uses a native menu bar by default; QMenuBar.setCornerWidget() (Current User,
+    # Private/Public toggle) is then unreliable or invisible. Force a Qt-drawn menu bar.
+    if sys.platform == "darwin":
+        QApplication.setAttribute(Qt.ApplicationAttribute.AA_DontUseNativeMenuBar, True)
     app = QApplication(sys.argv)
     if _LOGO_PATH.is_file():
         app.setWindowIcon(QIcon(str(_LOGO_PATH)))

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -612,8 +612,8 @@ class MainWindow(QMainWindow):
             self._visibility_btn = None
             try:
                 self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Ignoring failure while clearing top-right corner widget: %s", exc)
 
     def _rebuild_menu_corners(self) -> None:
         """Recreate menu corner widgets (needed after switching users)."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -424,7 +424,7 @@ class MainWindow(QMainWindow):
             ):
                 _lock_widget(w)
         except Exception:
-            pass
+            logger.exception("Failed to lock neuron detection controls for public user mode.")
 
         # View-only tabs (ROI Intensity, Trajectories, Lomb–Scargle) are intentionally
         # left fully interactive for the Public User. These controls only affect

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -620,11 +620,11 @@ class MainWindow(QMainWindow):
         try:
             self.menuBar().setCornerWidget(None, Qt.Corner.TopLeftCorner)
         except Exception:
-            pass
+            logger.debug("Ignoring failure while clearing top-left menu corner widget.", exc_info=True)
         try:
             self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
         except Exception:
-            pass
+            logger.debug("Ignoring failure while clearing top-right menu corner widget.", exc_info=True)
         self._current_user_btn = None
         self._visibility_btn = None
         self._init_current_user_menu_corner()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,8 +8,6 @@ from PySide6.QtCore import Qt, QTime, QTimer, QUrl
 from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices
 from PySide6.QtWidgets import (
     QApplication,
-    QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
@@ -38,13 +36,11 @@ from ui.analysis_panel import AnalysisPanel
 from ui.app_settings import get_enable_alignment_multiprocessing
 from ui.image_viewer import ImageViewer
 from ui.loading_dialog import LoadingDialog
-from ui.settings_dialog import SettingsDialog
-from ui.startup_dialog import StartupDialog
 from ui.public_user_dialog import (
     is_public_user,
-    register_public_experiment,
-    unregister_public_experiment,
 )
+from ui.settings_dialog import SettingsDialog
+from ui.startup_dialog import StartupDialog
 from ui.user_selection_dialog import UserAccountActionsDialog, UserSelectionDialog, current_user_button_text
 from ui.workflow import STEP_DEFINITIONS, WorkflowManager, WorkflowStep, WorkflowStepper
 from utils.file_handler import ImageStackHandler, _get_exif_timestamp
@@ -236,6 +232,12 @@ class MainWindow(QMainWindow):
         self.user_recent_file: Path | None = recent_file
         self._current_user_btn: QPushButton | None = None
         self._visibility_btn: QPushButton | None = None
+        self._action_save: QAction | None = None
+        self._action_save_as: QAction | None = None
+        self._action_experiment_settings: QAction | None = None
+        self._action_crop: QAction | None = None
+        # (widget, guard, was_enabled) so we can restore state when switching away from Public User.
+        self._public_user_guards: list[tuple[QWidget, object, bool]] = []
         self.image_processor = ImageProcessor(experiment)
         self._alignment_worker: AlignmentWorker | None = None
 
@@ -374,6 +376,29 @@ class MainWindow(QMainWindow):
 
         from ui.public_user_dialog import ReadOnlyGuard
 
+        def _lock_widget(w: QWidget) -> None:
+            try:
+                was_enabled = bool(w.isEnabled())
+                guard = ReadOnlyGuard.lock(w)
+                self._public_user_guards.append((w, guard, was_enabled))
+            except Exception:
+                pass
+
+        # Disable global write actions (saving/settings/tools).
+        for act in (
+            self._action_save,
+            self._action_save_as,
+            self._action_open_stack,
+            self._action_align_images,
+            self._action_crop,
+            self._action_experiment_settings,
+        ):
+            try:
+                if act is not None:
+                    act.setEnabled(False)
+            except Exception:
+                pass
+
         # Workflow navigation locked — Public User stays on Analysis
         self.workflow_stepper.set_read_only(True)
 
@@ -386,41 +411,29 @@ class MainWindow(QMainWindow):
         try:
             d = self.analysis.get_neuron_detection_widget()
             for w in (
-                d.detect_mode_combo, d.cell_size_spin, d.num_peaks_spin,
-                d.correlation_threshold_spin, d.max_absent_frames_spin,
-                d.threshold_rel_spin, d.max_projection_checkbox,
-                d.preprocess_sigma_spin, d.detrending_checkbox,
+                d.detect_mode_combo,
+                d.cell_size_spin,
+                d.num_peaks_spin,
+                d.correlation_threshold_spin,
+                d.max_absent_frames_spin,
+                d.threshold_rel_spin,
+                d.max_projection_checkbox,
+                d.preprocess_sigma_spin,
+                d.detrending_checkbox,
                 d.detect_btn,
             ):
-                ReadOnlyGuard.lock(w)
+                _lock_widget(w)
         except Exception:
             pass
 
-        # ROI Intensity tab: lock all display toggles; export buttons stay free.
-        try:
-            r = self.analysis.get_roi_plot_widget()
-            for cb in r.findChildren(QCheckBox):
-                ReadOnlyGuard.lock(cb)
-        except Exception:
-            pass
-
-        # Trajectories tab: lock display toggles and ROI selector; exports stay free.
-        try:
-            t = self.analysis.get_neuron_trajectory_plot_widget()
-            for cb in t.findChildren(QCheckBox):
-                ReadOnlyGuard.lock(cb)
-            ReadOnlyGuard.lock(t.roi_view_combo)
-        except Exception:
-            pass
-
-        # Lomb-Scargle tab: lock ROI checkboxes, axis mode, and interval spinbox;
-        # exports stay free.
+        # View-only tabs (ROI Intensity, Trajectories, Lomb–Scargle) are intentionally
+        # left fully interactive for the Public User. These controls only affect
+        # visualization, not persisted experiment data.
+        #
+        # Exception: Lomb–Scargle sampling interval is restricted for the Public User.
         try:
             ls = self.analysis.get_lomb_scargle_widget()
-            for cb in ls.findChildren(QCheckBox):
-                ReadOnlyGuard.lock(cb)
-            ReadOnlyGuard.lock(ls.axis_mode_combo)
-            ReadOnlyGuard.lock(ls.sampling_interval_spin)
+            _lock_widget(ls.sampling_interval_spin)
         except Exception:
             pass
 
@@ -430,12 +443,66 @@ class MainWindow(QMainWindow):
         try:
             rp = self.analysis.get_rayleigh_plot_widget()
             for w in (
-                rp.start_time_edit, rp.interval_spin,
-                rp.interval_unit_combo, rp.plot_btn,
+                rp.start_time_edit,
+                rp.interval_spin,
+                rp.interval_unit_combo,
+                rp.plot_btn,
             ):
-                ReadOnlyGuard.lock(w)
+                _lock_widget(w)
         except Exception:
             pass
+
+    def _clear_public_user_restrictions(self) -> None:
+        """Remove read-only guards and re-enable normal-user actions."""
+        # Remove event filters installed by ReadOnlyGuard
+        for widget, guard, was_enabled in self._public_user_guards:
+            try:
+                widget.removeEventFilter(guard)  # type: ignore[arg-type]
+            except Exception:
+                pass
+            try:
+                widget.setEnabled(was_enabled)
+            except Exception:
+                pass
+        self._public_user_guards.clear()
+
+        # Re-enable actions; workflow gating will re-disable as needed.
+        for act in (
+            self._action_save,
+            self._action_save_as,
+            self._action_open_stack,
+            self._action_align_images,
+            self._action_crop,
+            self._action_experiment_settings,
+        ):
+            try:
+                if act is not None:
+                    act.setEnabled(True)
+            except Exception:
+                pass
+
+        try:
+            self.workflow_stepper.set_read_only(False)
+        except Exception:
+            pass
+
+        # Re-apply workflow enable/disable rules after unlocking.
+        try:
+            self.workflow_manager.refresh_state()
+        except Exception:
+            pass
+        try:
+            # Some UI elements (especially inside graph widgets) are toggled via the state_changed signal.
+            self.workflow_manager.state_changed.emit()
+        except Exception:
+            pass
+
+    def _sync_public_user_mode(self) -> None:
+        """Ensure restrictions match the currently active user."""
+        if self._is_public_user_mode():
+            self._apply_public_user_restrictions()
+        else:
+            self._clear_public_user_restrictions()
 
     def _save_workflow_progress(self) -> None:
         if not self.current_experiment_path:
@@ -465,6 +532,8 @@ class MainWindow(QMainWindow):
         export_results_action = QAction("Export Results", self)
 
         # Keep references to actions we will control via workflow
+        self._action_save = save_action
+        self._action_save_as = save_as_action
         self._action_open_stack = open_stack_action
 
         save_action.setShortcut("Ctrl+S")
@@ -492,12 +561,14 @@ class MainWindow(QMainWindow):
         self._edit_menu.addAction(settings_action)
         experiment_settings_action = QAction("Experiment Settings...", self)
         experiment_settings_action.triggered.connect(self._open_experiment_settings)
+        self._action_experiment_settings = experiment_settings_action
         self._edit_menu.addAction(experiment_settings_action)
         self._tools_menu = menubar.addMenu("Tools")
 
         # Add crop action
         crop_action = QAction("Crop Stack to ROI", self)
         crop_action.triggered.connect(self._crop_stack_to_roi)
+        self._action_crop = crop_action
         self._tools_menu.addAction(crop_action)
 
         # Add alignment action
@@ -528,11 +599,31 @@ class MainWindow(QMainWindow):
             self._visibility_btn.setProperty("class", "tab-action")
             self._visibility_btn.setEnabled(False)
             self._visibility_btn.setToolTip(
-                "Make this experiment visible to the Public User.\n"
-                "Available once the Analysis step is reached."
+                "Make this experiment visible to the Public User.\nAvailable once the Analysis step is reached."
             )
             self._visibility_btn.clicked.connect(self._toggle_experiment_visibility)
             self.menuBar().setCornerWidget(self._visibility_btn, Qt.Corner.TopRightCorner)
+        else:
+            # Ensure any prior session's visibility button is removed when switching into Public mode.
+            self._visibility_btn = None
+            try:
+                self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
+            except Exception:
+                pass
+
+    def _rebuild_menu_corners(self) -> None:
+        """Recreate menu corner widgets (needed after switching users)."""
+        try:
+            self.menuBar().setCornerWidget(None, Qt.Corner.TopLeftCorner)
+        except Exception:
+            pass
+        try:
+            self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
+        except Exception:
+            pass
+        self._current_user_btn = None
+        self._visibility_btn = None
+        self._init_current_user_menu_corner()
 
     def _is_public_user_mode(self) -> bool:
         """Return True when the current session belongs to the Public User."""
@@ -565,7 +656,6 @@ class MainWindow(QMainWindow):
             # Revert to private without a confirmation prompt
             self.experiment.is_public = False
             if self.current_experiment_path:
-                unregister_public_experiment(self.current_experiment_path)
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception:
@@ -574,8 +664,7 @@ class MainWindow(QMainWindow):
             reply = QMessageBox.question(
                 self,
                 "Make Experiment Public",
-                "This will make the experiment viewable by the Public User.\n\n"
-                "Do you wish to proceed?",
+                "This will make the experiment viewable by the Public User.\n\nDo you wish to proceed?",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
             )
@@ -583,11 +672,18 @@ class MainWindow(QMainWindow):
                 return
             self.experiment.is_public = True
             if self.current_experiment_path:
-                register_public_experiment(self.current_experiment_path, self.experiment.name)
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception:
                     pass
+
+        # Rebuild the Public user's view immediately (copy-based sync).
+        try:
+            from ui.public_user_dialog import sync_public_experiments
+
+            sync_public_experiments()
+        except Exception:
+            pass
         self._update_visibility_button()
 
     def _reload_workbench_after_startup_choice(self, startup: StartupDialog) -> None:
@@ -596,7 +692,7 @@ class MainWindow(QMainWindow):
         self.user_experiments_dir = startup.experiments_dir
         self.user_recent_file = startup.experiments_dir.parent / "recent_experiments.json"
         self.manager = ExperimentManager(self.user_recent_file)
-        self._update_current_user_button_text()
+        self._rebuild_menu_corners()
 
         self.experiment = startup.experiment  # type: ignore[assignment]
         self.set_current_experiment_path(startup.experiment_path, persist_workflow=False)
@@ -604,6 +700,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(f"Neurolight - {self.experiment.name}")
         self.image_processor = ImageProcessor(self.experiment)
         self._update_visibility_button()
+        self._sync_public_user_mode()
 
         self.viewer.reset()
 
@@ -701,10 +798,11 @@ class MainWindow(QMainWindow):
         self.user_experiments_dir = user_dialog.selected_user_experiments_dir
         self.user_recent_file = self.user_experiments_dir.parent / "recent_experiments.json"
         self.manager = ExperimentManager(self.user_recent_file)
-        self._update_current_user_button_text()
+        self._rebuild_menu_corners()
 
         if self._is_public_user_mode():
             from ui.public_user_dialog import sync_public_experiments
+
             sync_public_experiments()
 
         startup = StartupDialog(self.user_experiments_dir)
@@ -741,6 +839,9 @@ class MainWindow(QMainWindow):
             self.viewer._show_current()  # redraw ROI overlays with new colours
 
     def _open_experiment_settings(self) -> None:
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         # Open the Experiment Settings dialog to edit metadata and acquisition timing.
         if self.experiment is None or not self.current_experiment_path:
             QMessageBox.information(
@@ -790,7 +891,7 @@ class MainWindow(QMainWindow):
             self._sync_rois_to_experiment()
             self._capture_display_settings()
             self._capture_experiment_time_settings()
-            if self.current_experiment_path:
+            if self.current_experiment_path and not self._is_public_user_mode():
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception as e:
@@ -1111,6 +1212,9 @@ class MainWindow(QMainWindow):
             pass
 
     def _open_image_stack(self) -> None:
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         directory = QFileDialog.getExistingDirectory(self, "Select Image Stack Folder", "")
         if not directory:
             return
@@ -1130,7 +1234,7 @@ class MainWindow(QMainWindow):
         detection_widget.set_frame_data(frame_data)
 
         # Persist immediately if we know the path to the .nexp
-        if self.current_experiment_path:
+        if self.current_experiment_path and not self._is_public_user_mode():
             try:
                 self.manager.save_experiment(self.experiment, self.current_experiment_path)
             except Exception:
@@ -1228,7 +1332,7 @@ class MainWindow(QMainWindow):
 
     def _save_neuron_detection(self) -> None:
         """Save experiment when neuron detection completes."""
-        if self.current_experiment_path:
+        if self.current_experiment_path and not self._is_public_user_mode():
             try:
                 self._sync_rois_to_experiment()
                 self._capture_display_settings()
@@ -1239,6 +1343,9 @@ class MainWindow(QMainWindow):
                 logger.error(f"Failed to save neuron detection data: {e}", exc_info=True)
 
     def _save(self) -> None:
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         if not self.current_experiment_path:
             self._save_as()
             return
@@ -1253,6 +1360,9 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Error", str(e))
 
     def _save_as(self) -> None:
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         default_dir = ""
         if self.current_experiment_path:
             try:
@@ -1300,7 +1410,7 @@ class MainWindow(QMainWindow):
         self._flush_pending_display_settings()
         self._sync_rois_to_experiment()
         self._capture_display_settings()
-        if self.current_experiment_path:
+        if self.current_experiment_path and not self._is_public_user_mode():
             try:
                 self.manager.save_experiment(self.experiment, self.current_experiment_path)
             except Exception:
@@ -1318,6 +1428,7 @@ class MainWindow(QMainWindow):
 
         if self._is_public_user_mode():
             from ui.public_user_dialog import sync_public_experiments
+
             sync_public_experiments()
 
         startup = StartupDialog(experiments_root)
@@ -1589,7 +1700,7 @@ class MainWindow(QMainWindow):
             self._pending_contrast = None
 
             # Persist to file if we have a path
-            if self.current_experiment_path:
+            if self.current_experiment_path and not self._is_public_user_mode():
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception:
@@ -1597,6 +1708,8 @@ class MainWindow(QMainWindow):
 
     def _save_roi_to_experiment(self, roi_key: str, roi: ROI) -> None:
         """Save a specific ROI to experiment and persist to .nexp file."""
+        if self._is_public_user_mode():
+            return
         self.experiment.rois[roi_key] = roi.to_dict()
         if self.current_experiment_path:
             try:
@@ -1606,6 +1719,8 @@ class MainWindow(QMainWindow):
                 pass
 
     def autosave_experiment(self) -> None:
+        if self._is_public_user_mode():
+            return
         if not self.experiment.settings.get("processing", {}).get("auto_save", True):
             return
         if not self.current_experiment_path:
@@ -1621,6 +1736,9 @@ class MainWindow(QMainWindow):
 
     def _crop_stack_to_roi(self) -> None:
         """Crop the image stack to the active ROI and save as new stack."""
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         current_roi = self.viewer.get_current_roi()
         if current_roi is None:
             QMessageBox.warning(self, "No ROI Selected", "Please select an ROI before cropping.")
@@ -1690,6 +1808,9 @@ class MainWindow(QMainWindow):
 
     def _align_images(self) -> None:
         """Align images in the stack using a background worker thread."""
+        if self._is_public_user_mode():
+            QMessageBox.information(self, "Public User", "This experiment is read-only for the Public User.")
+            return
         # Guard: prevent re-entry while a worker is already running
         if self._alignment_worker is not None and self._alignment_worker.isRunning():
             QMessageBox.warning(

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -397,7 +397,7 @@ class MainWindow(QMainWindow):
                 if act is not None:
                     act.setEnabled(False)
             except Exception:
-                pass
+                logger.exception("Failed to disable action in public user mode: %r", act)
 
         # Workflow navigation locked — Public User stays on Analysis
         self.workflow_stepper.set_read_only(True)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -450,7 +450,7 @@ class MainWindow(QMainWindow):
             ):
                 _lock_widget(w)
         except Exception:
-            pass
+            logger.exception("Failed to apply Public User restrictions to Rayleigh/Rao controls")
 
     def _clear_public_user_restrictions(self) -> None:
         """Remove read-only guards and re-enable normal-user actions."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -459,7 +459,7 @@ class MainWindow(QMainWindow):
             try:
                 widget.removeEventFilter(guard)  # type: ignore[arg-type]
             except Exception:
-                pass
+                logger.debug("Non-fatal: failed to remove public-user event filter from widget.", exc_info=True)
             try:
                 widget.setEnabled(was_enabled)
             except Exception:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -464,7 +464,9 @@ class MainWindow(QMainWindow):
                 widget.setEnabled(was_enabled)
             except Exception:
                 # Best-effort restore: widget may already be deleted or in an invalid Qt state.
-                logger.debug("Failed to restore widget enabled state while clearing public user restrictions.", exc_info=True)
+                logger.debug(
+                    "Failed to restore widget enabled state while clearing public user restrictions.", exc_info=True
+                )
         self._public_user_guards.clear()
 
         # Re-enable actions; workflow gating will re-disable as needed.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -485,7 +485,7 @@ class MainWindow(QMainWindow):
         try:
             self.workflow_stepper.set_read_only(False)
         except Exception:
-            pass
+            logger.debug("Failed to clear read-only mode on workflow_stepper.", exc_info=True)
 
         # Re-apply workflow enable/disable rules after unlocking.
         try:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -435,7 +435,7 @@ class MainWindow(QMainWindow):
             ls = self.analysis.get_lomb_scargle_widget()
             _lock_widget(ls.sampling_interval_spin)
         except Exception:
-            pass
+            logger.exception("Failed to apply Public User restriction to Lomb–Scargle sampling interval.")
 
         # Rayleigh/Rao tab: lock time-setting inputs and the plot button
         # (these drive re-computation that writes back to the experiment).

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -491,7 +491,7 @@ class MainWindow(QMainWindow):
         try:
             self.workflow_manager.refresh_state()
         except Exception:
-            pass
+            logger.exception("Failed to refresh workflow state while clearing public-user restrictions.")
         try:
             # Some UI elements (especially inside graph widgets) are toggled via the state_changed signal.
             self.workflow_manager.state_changed.emit()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -463,7 +463,8 @@ class MainWindow(QMainWindow):
             try:
                 widget.setEnabled(was_enabled)
             except Exception:
-                pass
+                # Best-effort restore: widget may already be deleted or in an invalid Qt state.
+                logger.debug("Failed to restore widget enabled state while clearing public user restrictions.", exc_info=True)
         self._public_user_guards.clear()
 
         # Re-enable actions; workflow gating will re-disable as needed.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -382,7 +382,7 @@ class MainWindow(QMainWindow):
                 guard = ReadOnlyGuard.lock(w)
                 self._public_user_guards.append((w, guard, was_enabled))
             except Exception:
-                pass
+                logger.exception("Failed to apply public-user lock to widget %r", w)
 
         # Disable global write actions (saving/settings/tools).
         for act in (

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -496,7 +496,10 @@ class MainWindow(QMainWindow):
             # Some UI elements (especially inside graph widgets) are toggled via the state_changed signal.
             self.workflow_manager.state_changed.emit()
         except Exception:
-            pass
+            logger.debug(
+                "Non-fatal: failed to emit workflow_manager.state_changed while clearing public-user restrictions.",
+                exc_info=True,
+            )
 
     def _sync_public_user_mode(self) -> None:
         """Ensure restrictions match the currently active user."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -663,7 +663,7 @@ class MainWindow(QMainWindow):
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception:
-                    pass
+                    logger.exception("Failed to save experiment after setting visibility to private.")
         else:
             reply = QMessageBox.question(
                 self,
@@ -679,7 +679,7 @@ class MainWindow(QMainWindow):
                 try:
                     self.manager.save_experiment(self.experiment, self.current_experiment_path)
                 except Exception:
-                    pass
+                    logger.exception("Failed to save experiment after setting visibility to public.")
 
         # Rebuild the Public user's view immediately (copy-based sync).
         try:
@@ -687,7 +687,7 @@ class MainWindow(QMainWindow):
 
             sync_public_experiments()
         except Exception:
-            pass
+            logger.exception("Failed to sync public experiments after visibility change.")
         self._update_visibility_button()
 
     def _reload_workbench_after_startup_choice(self, startup: StartupDialog) -> None:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMainWindow,
@@ -232,6 +233,7 @@ class MainWindow(QMainWindow):
         self.user_recent_file: Path | None = recent_file
         self._current_user_btn: QPushButton | None = None
         self._visibility_btn: QPushButton | None = None
+        self._header_bar: QWidget | None = None
         self._action_save: QAction | None = None
         self._action_save_as: QAction | None = None
         self._action_experiment_settings: QAction | None = None
@@ -263,7 +265,6 @@ class MainWindow(QMainWindow):
         self.workflow_stepper.requestAlignImages.connect(self._align_images)
 
         self._init_menu()
-        self._init_current_user_menu_corner()
         self._init_layout()
 
     # ------------------------------------------------------------------
@@ -589,17 +590,35 @@ class MainWindow(QMainWindow):
         about_action = help_meun.addAction("About")
         about_action.triggered.connect(self.open_website)
 
-    def _init_current_user_menu_corner(self) -> None:
+    def _init_header_bar(self) -> None:
+        """Create the in-window header bar (cross-platform).
+
+        On macOS, Qt uses the native menu bar by default; native menu bars don't
+        reliably render ``QMenuBar.setCornerWidget``. Keeping these controls
+        inside the window makes the UI consistent across OSes.
+        """
+        # Clear any previous references
+        self._header_bar = None
+        self._current_user_btn = None
+        self._visibility_btn = None
+
         if self.user_experiments_dir is None:
             return
 
-        # User button — left corner, exactly as the original code had it.
+        header = QWidget()
+        header.setObjectName("mainWindowHeaderBar")
+        row = QHBoxLayout(header)
+        row.setContentsMargins(8, 6, 8, 6)
+        row.setSpacing(8)
+
         self._current_user_btn = QPushButton(current_user_button_text(self.user_experiments_dir.parent.name))
         self._current_user_btn.setProperty("class", "tab-action")
         self._current_user_btn.clicked.connect(self._open_user_account_popup)
-        self.menuBar().setCornerWidget(self._current_user_btn, Qt.Corner.TopLeftCorner)
+        row.addWidget(self._current_user_btn, 0, Qt.AlignmentFlag.AlignLeft)
 
-        # Private / Public toggle — right corner, hidden for Public User.
+        row.addStretch(1)
+
+        # Private / Public toggle — hidden for Public User.
         if not self._is_public_user_mode():
             self._visibility_btn = QPushButton("Private")
             self._visibility_btn.setProperty("class", "tab-action")
@@ -608,28 +627,34 @@ class MainWindow(QMainWindow):
                 "Make this experiment visible to the Public User.\nAvailable once the Analysis step is reached."
             )
             self._visibility_btn.clicked.connect(self._toggle_experiment_visibility)
-            self.menuBar().setCornerWidget(self._visibility_btn, Qt.Corner.TopRightCorner)
+            row.addWidget(self._visibility_btn, 0, Qt.AlignmentFlag.AlignRight)
+            self._update_visibility_button()
         else:
-            # Ensure any prior session's visibility button is removed when switching into Public mode.
             self._visibility_btn = None
-            try:
-                self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
-            except Exception as exc:
-                logger.debug("Ignoring failure while clearing top-right corner widget: %s", exc)
 
-    def _rebuild_menu_corners(self) -> None:
-        """Recreate menu corner widgets (needed after switching users)."""
-        try:
-            self.menuBar().setCornerWidget(None, Qt.Corner.TopLeftCorner)
-        except Exception:
-            logger.debug("Ignoring failure while clearing top-left menu corner widget.", exc_info=True)
-        try:
-            self.menuBar().setCornerWidget(None, Qt.Corner.TopRightCorner)
-        except Exception:
-            logger.debug("Ignoring failure while clearing top-right menu corner widget.", exc_info=True)
-        self._current_user_btn = None
-        self._visibility_btn = None
-        self._init_current_user_menu_corner()
+        self._header_bar = header
+
+    def _rebuild_header_bar(self) -> None:
+        """Recreate header bar widgets (needed after switching users)."""
+        container = self.centralWidget()
+        if container is None:
+            self._init_header_bar()
+            return
+        layout = container.layout()
+        if layout is None:
+            self._init_header_bar()
+            return
+
+        if self._header_bar is not None:
+            try:
+                layout.removeWidget(self._header_bar)
+                self._header_bar.deleteLater()
+            except Exception:
+                logger.debug("Ignoring failure while removing header bar.", exc_info=True)
+
+        self._init_header_bar()
+        if self._header_bar is not None:
+            layout.insertWidget(0, self._header_bar)
 
     def _is_public_user_mode(self) -> bool:
         """Return True when the current session belongs to the Public User."""
@@ -698,7 +723,7 @@ class MainWindow(QMainWindow):
         self.user_experiments_dir = startup.experiments_dir
         self.user_recent_file = startup.experiments_dir.parent / "recent_experiments.json"
         self.manager = ExperimentManager(self.user_recent_file)
-        self._rebuild_menu_corners()
+        self._rebuild_header_bar()
 
         self.experiment = startup.experiment  # type: ignore[assignment]
         self.set_current_experiment_path(startup.experiment_path, persist_workflow=False)
@@ -804,7 +829,7 @@ class MainWindow(QMainWindow):
         self.user_experiments_dir = user_dialog.selected_user_experiments_dir
         self.user_recent_file = self.user_experiments_dir.parent / "recent_experiments.json"
         self.manager = ExperimentManager(self.user_recent_file)
-        self._rebuild_menu_corners()
+        self._rebuild_header_bar()
 
         if self._is_public_user_mode():
             from ui.public_user_dialog import sync_public_experiments
@@ -982,6 +1007,9 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
+        self._init_header_bar()
+        if self._header_bar is not None:
+            layout.addWidget(self._header_bar)
         layout.addWidget(self.workflow_stepper)
         layout.addWidget(splitter)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -480,7 +480,7 @@ class MainWindow(QMainWindow):
                 if act is not None:
                     act.setEnabled(True)
             except Exception:
-                pass
+                logger.debug("Failed to re-enable action during public-user restriction clear.", exc_info=True)
 
         try:
             self.workflow_stepper.set_read_only(False)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,6 +8,8 @@ from PySide6.QtCore import Qt, QTime, QTimer, QUrl
 from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices
 from PySide6.QtWidgets import (
     QApplication,
+    QCheckBox,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
@@ -38,6 +40,11 @@ from ui.image_viewer import ImageViewer
 from ui.loading_dialog import LoadingDialog
 from ui.settings_dialog import SettingsDialog
 from ui.startup_dialog import StartupDialog
+from ui.public_user_dialog import (
+    is_public_user,
+    register_public_experiment,
+    unregister_public_experiment,
+)
 from ui.user_selection_dialog import UserAccountActionsDialog, UserSelectionDialog, current_user_button_text
 from ui.workflow import STEP_DEFINITIONS, WorkflowManager, WorkflowStep, WorkflowStepper
 from utils.file_handler import ImageStackHandler, _get_exif_timestamp
@@ -228,6 +235,7 @@ class MainWindow(QMainWindow):
         self.user_experiments_dir = user_experiments_dir
         self.user_recent_file: Path | None = recent_file
         self._current_user_btn: QPushButton | None = None
+        self._visibility_btn: QPushButton | None = None
         self.image_processor = ImageProcessor(experiment)
         self._alignment_worker: AlignmentWorker | None = None
 
@@ -333,12 +341,101 @@ class MainWindow(QMainWindow):
                 )
                 self.analysis.setVisible(show_analysis)
 
+            # Enable the Private/Public toggle only once Analysis step is active or completed
+            if self._visibility_btn is not None:
+                analysis_reached = (
+                    current == WorkflowStep.ANALYZE_GRAPHS
+                    or WorkflowStep.ANALYZE_GRAPHS in self.workflow_manager.completed_steps
+                )
+                self._visibility_btn.setEnabled(analysis_reached)
+                self._update_visibility_button()
+
         # Connect workflow manager notifications
         self.workflow_manager.step_changed.connect(lambda _step: refresh_controls())
         self.workflow_manager.state_changed.connect(refresh_controls)
 
         # Apply initial state
         refresh_controls()
+
+    def _apply_public_user_restrictions(self) -> None:
+        """Lock data-modification controls when running as the Public User.
+
+        Public Users may view and export freely.  What is blocked:
+        - Workflow navigation (cannot go back/forward in steps)
+        - Detection controls (cannot re-run or modify detection)
+        - Rayleigh time settings (cannot change computation inputs)
+
+        Export buttons are intentionally left untouched everywhere.
+        Restrictions are applied via ReadOnlyGuard — no shared widget code
+        is modified.
+        """
+        if not self._is_public_user_mode():
+            return
+
+        from ui.public_user_dialog import ReadOnlyGuard
+
+        # Workflow navigation locked — Public User stays on Analysis
+        self.workflow_stepper.set_read_only(True)
+
+        if not hasattr(self, "analysis"):
+            return
+
+        # Detection tab: lock all parameter inputs and the detect button.
+        # Export buttons (export_locations_btn, export_trajectories_btn,
+        # export_all_btn) are left enabled — exporting is allowed.
+        try:
+            d = self.analysis.get_neuron_detection_widget()
+            for w in (
+                d.detect_mode_combo, d.cell_size_spin, d.num_peaks_spin,
+                d.correlation_threshold_spin, d.max_absent_frames_spin,
+                d.threshold_rel_spin, d.max_projection_checkbox,
+                d.preprocess_sigma_spin, d.detrending_checkbox,
+                d.detect_btn,
+            ):
+                ReadOnlyGuard.lock(w)
+        except Exception:
+            pass
+
+        # ROI Intensity tab: lock all display toggles; export buttons stay free.
+        try:
+            r = self.analysis.get_roi_plot_widget()
+            for cb in r.findChildren(QCheckBox):
+                ReadOnlyGuard.lock(cb)
+        except Exception:
+            pass
+
+        # Trajectories tab: lock display toggles and ROI selector; exports stay free.
+        try:
+            t = self.analysis.get_neuron_trajectory_plot_widget()
+            for cb in t.findChildren(QCheckBox):
+                ReadOnlyGuard.lock(cb)
+            ReadOnlyGuard.lock(t.roi_view_combo)
+        except Exception:
+            pass
+
+        # Lomb-Scargle tab: lock ROI checkboxes, axis mode, and interval spinbox;
+        # exports stay free.
+        try:
+            ls = self.analysis.get_lomb_scargle_widget()
+            for cb in ls.findChildren(QCheckBox):
+                ReadOnlyGuard.lock(cb)
+            ReadOnlyGuard.lock(ls.axis_mode_combo)
+            ReadOnlyGuard.lock(ls.sampling_interval_spin)
+        except Exception:
+            pass
+
+        # Rayleigh/Rao tab: lock time-setting inputs and the plot button
+        # (these drive re-computation that writes back to the experiment).
+        # Export buttons are left enabled.
+        try:
+            rp = self.analysis.get_rayleigh_plot_widget()
+            for w in (
+                rp.start_time_edit, rp.interval_spin,
+                rp.interval_unit_combo, rp.plot_btn,
+            ):
+                ReadOnlyGuard.lock(w)
+        except Exception:
+            pass
 
     def _save_workflow_progress(self) -> None:
         if not self.current_experiment_path:
@@ -418,15 +515,80 @@ class MainWindow(QMainWindow):
     def _init_current_user_menu_corner(self) -> None:
         if self.user_experiments_dir is None:
             return
+
+        # User button — left corner, exactly as the original code had it.
         self._current_user_btn = QPushButton(current_user_button_text(self.user_experiments_dir.parent.name))
         self._current_user_btn.setProperty("class", "tab-action")
         self._current_user_btn.clicked.connect(self._open_user_account_popup)
         self.menuBar().setCornerWidget(self._current_user_btn, Qt.Corner.TopLeftCorner)
 
+        # Private / Public toggle — right corner, hidden for Public User.
+        if not self._is_public_user_mode():
+            self._visibility_btn = QPushButton("Private")
+            self._visibility_btn.setProperty("class", "tab-action")
+            self._visibility_btn.setEnabled(False)
+            self._visibility_btn.setToolTip(
+                "Make this experiment visible to the Public User.\n"
+                "Available once the Analysis step is reached."
+            )
+            self._visibility_btn.clicked.connect(self._toggle_experiment_visibility)
+            self.menuBar().setCornerWidget(self._visibility_btn, Qt.Corner.TopRightCorner)
+
+    def _is_public_user_mode(self) -> bool:
+        """Return True when the current session belongs to the Public User."""
+        if self.user_experiments_dir is None:
+            return False
+        return is_public_user(self.user_experiments_dir.parent.name)
+
     def _update_current_user_button_text(self) -> None:
         if self._current_user_btn is None or self.user_experiments_dir is None:
             return
         self._current_user_btn.setText(current_user_button_text(self.user_experiments_dir.parent.name))
+
+    def _update_visibility_button(self) -> None:
+        """Sync the Private/Public button label and style with experiment.is_public."""
+        if self._visibility_btn is None:
+            return
+        if self.experiment.is_public:
+            self._visibility_btn.setText("Public")
+            self._visibility_btn.setProperty("class", "primary")
+        else:
+            self._visibility_btn.setText("Private")
+            self._visibility_btn.setProperty("class", "tab-action")
+        # Force stylesheet re-evaluation after property change
+        self._visibility_btn.style().unpolish(self._visibility_btn)
+        self._visibility_btn.style().polish(self._visibility_btn)
+
+    def _toggle_experiment_visibility(self) -> None:
+        """Toggle the experiment between private and public visibility."""
+        if self.experiment.is_public:
+            # Revert to private without a confirmation prompt
+            self.experiment.is_public = False
+            if self.current_experiment_path:
+                unregister_public_experiment(self.current_experiment_path)
+                try:
+                    self.manager.save_experiment(self.experiment, self.current_experiment_path)
+                except Exception:
+                    pass
+        else:
+            reply = QMessageBox.question(
+                self,
+                "Make Experiment Public",
+                "This will make the experiment viewable by the Public User.\n\n"
+                "Do you wish to proceed?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return
+            self.experiment.is_public = True
+            if self.current_experiment_path:
+                register_public_experiment(self.current_experiment_path, self.experiment.name)
+                try:
+                    self.manager.save_experiment(self.experiment, self.current_experiment_path)
+                except Exception:
+                    pass
+        self._update_visibility_button()
 
     def _reload_workbench_after_startup_choice(self, startup: StartupDialog) -> None:
         """Apply an experiment chosen from StartupDialog and show the main window again."""
@@ -441,6 +603,7 @@ class MainWindow(QMainWindow):
         self.workflow_manager.attach_experiment(self.experiment)
         self.setWindowTitle(f"Neurolight - {self.experiment.name}")
         self.image_processor = ImageProcessor(self.experiment)
+        self._update_visibility_button()
 
         self.viewer.reset()
 
@@ -539,6 +702,10 @@ class MainWindow(QMainWindow):
         self.user_recent_file = self.user_experiments_dir.parent / "recent_experiments.json"
         self.manager = ExperimentManager(self.user_recent_file)
         self._update_current_user_button_text()
+
+        if self._is_public_user_mode():
+            from ui.public_user_dialog import sync_public_experiments
+            sync_public_experiments()
 
         startup = StartupDialog(self.user_experiments_dir)
         result = startup.exec()
@@ -715,6 +882,9 @@ class MainWindow(QMainWindow):
 
         # Initialize workflow-driven enable/disable state
         self._init_workflow_bindings()
+
+        # Apply read-only restrictions when running as the Public User
+        self._apply_public_user_restrictions()
 
         # Auto-load image stack/ROI if experiment has saved data
         self._auto_load_experiment_data()
@@ -1145,6 +1315,10 @@ class MainWindow(QMainWindow):
         # In tests (and some ad-hoc scripts), MainWindow may be constructed directly.
         # Fall back to the current working directory so the close flow remains testable.
         experiments_root = self.user_experiments_dir or Path.cwd()
+
+        if self._is_public_user_mode():
+            from ui.public_user_dialog import sync_public_experiments
+            sync_public_experiments()
 
         startup = StartupDialog(experiments_root)
         result = startup.exec()

--- a/src/ui/neuron_trajectory_plot.py
+++ b/src/ui/neuron_trajectory_plot.py
@@ -792,7 +792,9 @@ class NeuronTrajectoryPlotWidget(QWidget):
                 fontsize=9,
                 alpha=0.7,
             )
-        ax.legend(loc="best")
+        _handles, legend_labels = ax.get_legend_handles_labels()
+        if legend_labels:
+            ax.legend(loc="best")
         self._apply_theme(ax)
 
         # Update status label with peak/trough info if enabled

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -98,8 +98,13 @@ def ensure_public_user_exists() -> Path:
 
 
 def is_public_user(name: str) -> bool:
-    """Return True when *name* is the Public User account."""
-    return name == PUBLIC_USER_NAME
+    """Return True when *name* refers to the Public User account.
+
+    This intentionally tolerates casing/whitespace differences so that
+    cross-platform folder naming quirks (e.g. "public", "Public ") don't
+    break read-only behavior or syncing.
+    """
+    return name.strip().casefold() == PUBLIC_USER_NAME.casefold()
 
 
 def sync_public_experiments() -> None:

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from PySide6.QtCore import QEvent, QObject
 from PySide6.QtWidgets import QWidget
 
-
 PUBLIC_USER_NAME = "Public"
 
 
@@ -43,7 +42,7 @@ class ReadOnlyGuard(QObject):
         return False
 
     @classmethod
-    def lock(cls, widget: QWidget) -> "ReadOnlyGuard":
+    def lock(cls, widget: QWidget) -> ReadOnlyGuard:
         """Disable *widget* and install the guard.  Returns the guard instance."""
         guard = cls(widget)
         widget.installEventFilter(guard)
@@ -129,7 +128,10 @@ def sync_public_experiments() -> None:
                     data = json.load(fh)
             except Exception:
                 continue
-            if not data.get("is_public", False):
+            exp = data.get("experiment") or {}
+            if not isinstance(exp, dict):
+                exp = {}
+            if not exp.get("is_public", False):
                 continue
 
             # Collision-free filename: <owner>__<original stem>.nexp
@@ -141,11 +143,13 @@ def sync_public_experiments() -> None:
                 continue
 
             keep_names.add(dest_name)
-            recent_entries.append({
-                "path": str(dest.resolve()),
-                "name": data.get("name", nexp_file.stem),
-                "last_opened": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            })
+            recent_entries.append(
+                {
+                    "path": str(dest.resolve()),
+                    "name": exp.get("name", nexp_file.stem),
+                    "last_opened": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                }
+            )
 
     # Rewrite the recent list with exactly the current public set
     try:

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -147,6 +147,7 @@ def sync_public_experiments() -> None:
                 {
                     "path": str(dest.resolve()),
                     "name": exp.get("name", nexp_file.stem),
+                    "owner": user_dir.name,
                     "last_opened": datetime.now(timezone.utc).isoformat(timespec="seconds"),
                 }
             )

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -1,0 +1,223 @@
+"""Public User management.
+
+The Public User is a special permanent read-only account that can view
+experiments explicitly marked public by their owners.  It cannot be deleted
+from the user-selection screen and has no write access to experiments.
+
+Public API:
+  - PUBLIC_USER_NAME            — constant name for the public account
+  - ReadOnlyGuard               — event filter that keeps a widget permanently disabled
+  - ensure_public_user_exists() — create the account directory if absent
+  - is_public_user(name)        — True when name == PUBLIC_USER_NAME
+  - sync_public_experiments()   — scan all users and copy public .nexp files to Public folder
+  - register_public_experiment(path, name) — expose an experiment to the Public User
+  - unregister_public_experiment(path)     — hide an experiment from the Public User
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from PySide6.QtCore import QEvent, QObject
+from PySide6.QtWidgets import QWidget
+
+
+PUBLIC_USER_NAME = "Public"
+
+
+class ReadOnlyGuard(QObject):
+    """Event filter that permanently keeps a widget disabled.
+
+    Install this on any button that internal widget code might re-enable
+    during a replot or data-load cycle.  Safe to install multiple times on
+    the same widget — duplicate installations are harmless.
+    """
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        # If something tried to enable the widget, immediately revert it.
+        if event.type() == QEvent.Type.EnabledChange and obj.isEnabled():
+            obj.setEnabled(False)
+        return False
+
+    @classmethod
+    def lock(cls, widget: QWidget) -> "ReadOnlyGuard":
+        """Disable *widget* and install the guard.  Returns the guard instance."""
+        guard = cls(widget)
+        widget.installEventFilter(guard)
+        widget.setEnabled(False)
+        return guard
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    # This file lives at src/ui/public_user_dialog.py
+    return Path(__file__).resolve().parents[2]
+
+
+def _public_user_dir() -> Path:
+    return _repo_root() / "users" / PUBLIC_USER_NAME
+
+
+def _public_experiments_dir() -> Path:
+    return _public_user_dir() / "experiments"
+
+
+def _public_recent_file() -> Path:
+    return _public_user_dir() / "recent_experiments.json"
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_public_user_exists() -> Path:
+    """Create the Public user directory structure if it does not exist.
+
+    Returns the experiments directory path so callers can pass it to
+    StartupDialog directly.
+    """
+    exp_dir = _public_experiments_dir()
+    try:
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        recent = _public_recent_file()
+        if not recent.exists():
+            recent.write_text(json.dumps({"recent": []}, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+    return exp_dir
+
+
+def is_public_user(name: str) -> bool:
+    """Return True when *name* is the Public User account."""
+    return name == PUBLIC_USER_NAME
+
+
+def sync_public_experiments() -> None:
+    """Rebuild the Public User's experiment list from all users' public experiments.
+
+    Walks every non-Public user directory under ``users/``, reads each ``.nexp``
+    file, and copies those flagged ``is_public=True`` into the Public User's
+    experiments folder using a collision-free name (``<owner>__<stem>.nexp``).
+    The Public User's ``recent_experiments.json`` is then rewritten to exactly
+    this set.  Stale copies from previously-public experiments are deleted.
+    """
+    pub_exp_dir = ensure_public_user_exists()
+    users_dir = _repo_root() / "users"
+    if not users_dir.is_dir():
+        return
+
+    recent_entries: list[dict] = []
+    keep_names: set[str] = set()
+
+    for user_dir in sorted(users_dir.iterdir()):
+        if not user_dir.is_dir() or user_dir.name == PUBLIC_USER_NAME:
+            continue
+        exp_dir = user_dir / "experiments"
+        if not exp_dir.is_dir():
+            continue
+        for nexp_file in sorted(exp_dir.rglob("*.nexp")):
+            try:
+                with open(nexp_file, encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except Exception:
+                continue
+            if not data.get("is_public", False):
+                continue
+
+            # Collision-free filename: <owner>__<original stem>.nexp
+            dest_name = f"{user_dir.name}__{nexp_file.stem}.nexp"
+            dest = pub_exp_dir / dest_name
+            try:
+                shutil.copy2(str(nexp_file), str(dest))
+            except OSError:
+                continue
+
+            keep_names.add(dest_name)
+            recent_entries.append({
+                "path": str(dest.resolve()),
+                "name": data.get("name", nexp_file.stem),
+                "last_opened": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            })
+
+    # Rewrite the recent list with exactly the current public set
+    try:
+        with open(_public_recent_file(), "w", encoding="utf-8") as fh:
+            json.dump({"recent": recent_entries}, fh, indent=2)
+    except OSError:
+        pass
+
+    # Remove stale copies that are no longer public
+    for f in pub_exp_dir.iterdir():
+        if f.suffix == ".nexp" and f.name not in keep_names:
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Experiment registration
+# ---------------------------------------------------------------------------
+
+
+def register_public_experiment(experiment_path: str, experiment_name: str | None = None) -> None:
+    """Add *experiment_path* to the Public user's accessible experiment list.
+
+    Safe to call multiple times for the same path (de-duplicates).
+    """
+    ensure_public_user_exists()
+    recent_file = _public_recent_file()
+    resolved = str(Path(experiment_path).resolve())
+
+    entry = {
+        "path": resolved,
+        "name": experiment_name or Path(resolved).stem,
+        "last_opened": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+
+    try:
+        with open(recent_file, encoding="utf-8") as f:
+            data = json.load(f) or {"recent": []}
+    except Exception:
+        data = {"recent": []}
+
+    # Remove any stale duplicate then prepend the fresh entry.
+    data["recent"] = [e for e in data.get("recent", []) if e.get("path") != resolved]
+    data["recent"].insert(0, entry)
+
+    try:
+        with open(recent_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError:
+        pass
+
+
+def unregister_public_experiment(experiment_path: str) -> None:
+    """Remove *experiment_path* from the Public user's accessible list."""
+    recent_file = _public_recent_file()
+    if not recent_file.exists():
+        return
+
+    resolved = str(Path(experiment_path).resolve())
+
+    try:
+        with open(recent_file, encoding="utf-8") as f:
+            data = json.load(f) or {"recent": []}
+    except Exception:
+        data = {"recent": []}
+
+    data["recent"] = [e for e in data.get("recent", []) if e.get("path") != resolved]
+
+    try:
+        with open(recent_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError:
+        pass

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -158,8 +159,8 @@ def sync_public_experiments() -> None:
     try:
         with open(_public_recent_file(), "w", encoding="utf-8") as fh:
             json.dump({"recent": recent_entries}, fh, indent=2)
-    except OSError:
-        pass
+    except OSError as exc:
+        print(f"Failed to write public recent experiments file: {exc}", file=sys.stderr)
 
     # Remove stale copies that are no longer public
     for f in pub_exp_dir.iterdir():

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -168,6 +168,8 @@ def sync_public_experiments() -> None:
             try:
                 f.unlink()
             except OSError:
+                # Best-effort cleanup: ignore deletion failures (e.g., file in use/permissions)
+                # so public experiment sync can continue.
                 pass
 
 

--- a/src/ui/public_user_dialog.py
+++ b/src/ui/public_user_dialog.py
@@ -90,6 +90,8 @@ def ensure_public_user_exists() -> Path:
         if not recent.exists():
             recent.write_text(json.dumps({"recent": []}, indent=2), encoding="utf-8")
     except OSError:
+        # Best-effort setup: ignore filesystem errors and let callers continue.
+        # Public mode may be unavailable if the directory cannot be created.
         pass
     return exp_dir
 

--- a/src/ui/startup_dialog.py
+++ b/src/ui/startup_dialog.py
@@ -44,6 +44,24 @@ from ui.user_selection_dialog import UserAccountActionsDialog, UserSelectionDial
 OPTIONS_LABEL = "..."
 
 
+def _public_recent_row_label(rec: dict, path: str) -> str:
+    """Label for Public User recent rows: experiment name — by owner.
+
+    *owner* is shown with the same casing as the user folder name (or the
+    ``owner`` field in recent JSON) — never normalized, so it matches the
+    profile name users see elsewhere.
+    """
+    name = (rec.get("name") or Path(path).stem if path else "").strip() or "Unnamed"
+    owner = rec.get("owner")
+    if not owner and path:
+        stem = Path(path).stem
+        if "__" in stem:
+            owner = stem.split("__", 1)[0]
+    if owner:
+        return f"{name} - by {owner}"
+    return name
+
+
 class RecentExperimentRow(QWidget):
     """Single row in the recent experiments list: centered name + options button (...)."""
 
@@ -296,7 +314,11 @@ class StartupDialog(QDialog):
                         continue
                 except Exception:
                     continue
-            name = rec.get("name") or Path(path).stem if path else ""
+            name = (
+                _public_recent_row_label(rec, path)
+                if self._public_mode
+                else (rec.get("name") or Path(path).stem if path else "")
+            )
             list_item = QListWidgetItem()
             list_item.setData(Qt.UserRole, path)
             list_item.setSizeHint(self._row_size_hint())

--- a/src/ui/startup_dialog.py
+++ b/src/ui/startup_dialog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from PySide6.QtCore import Qt, QUrl
 from PySide6.QtGui import QDesktopServices
@@ -44,6 +44,20 @@ from ui.user_selection_dialog import UserAccountActionsDialog, UserSelectionDial
 OPTIONS_LABEL = "..."
 
 
+def _path_stem(path: str) -> str:
+    """Filename stem; Windows paths must use PureWindowsPath on POSIX (CI/Linux).
+
+    ``pathlib.Path`` on Linux does not treat ``\\`` as a separator, so stems of
+    ``C:\\...\\owner__Name.nexp`` would wrongly include the full path prefix.
+    """
+    path = path.strip()
+    if not path:
+        return ""
+    if "\\" in path or (len(path) > 1 and path[1] == ":"):
+        return PureWindowsPath(path).stem
+    return Path(path).stem
+
+
 def _public_recent_row_label(rec: dict, path: str) -> str:
     """Label for Public User recent rows: experiment name — by owner.
 
@@ -51,10 +65,10 @@ def _public_recent_row_label(rec: dict, path: str) -> str:
     ``owner`` field in recent JSON) — never normalized, so it matches the
     profile name users see elsewhere.
     """
-    name = (rec.get("name") or Path(path).stem if path else "").strip() or "Unnamed"
+    name = (rec.get("name") or _path_stem(path) if path else "").strip() or "Unnamed"
     owner = rec.get("owner")
     if not owner and path:
-        stem = Path(path).stem
+        stem = _path_stem(path)
         if "__" in stem:
             owner = stem.split("__", 1)[0]
     if owner:

--- a/src/ui/startup_dialog.py
+++ b/src/ui/startup_dialog.py
@@ -36,6 +36,7 @@ from ui.app_settings import (
     get_enable_alignment_multiprocessing,
     set_enable_alignment_multiprocessing,
 )
+from ui.public_user_dialog import is_public_user
 from ui.settings_dialog import SettingsDialog
 from ui.user_selection_dialog import UserAccountActionsDialog, UserSelectionDialog, current_user_button_text
 
@@ -198,6 +199,7 @@ class StartupDialog(QDialog):
         self.setMinimumWidth(520)
         self.experiments_dir = experiments_dir
         self._current_user_name = experiments_dir.parent.name
+        self._public_mode = is_public_user(self._current_user_name)
         self.experiment: Experiment | None = None
         self.experiment_path: str | None = None
         # Store recent experiments per user (in the user's folder, not globally in ~/.neurolight).
@@ -218,6 +220,12 @@ class StartupDialog(QDialog):
         new_btn.setProperty("class", "tab-action")
         load_btn = QPushButton("Load Existing Experiment")
         load_btn.setProperty("class", "tab-action")
+
+        if self._public_mode:
+            new_btn.setEnabled(False)
+            new_btn.setToolTip("The Public User cannot create experiments.")
+            load_btn.setEnabled(False)
+            load_btn.setToolTip("The Public User cannot load arbitrary experiment files.")
 
         new_btn.clicked.connect(self._start_new)
         load_btn.clicked.connect(self._load_existing)
@@ -272,6 +280,7 @@ class StartupDialog(QDialog):
             return
         self.experiments_dir = picker.selected_user_experiments_dir
         self._current_user_name = picker.selected_user
+        self._public_mode = is_public_user(self._current_user_name)
         self._current_user_btn.setText(current_user_button_text(self._current_user_name))
         self.manager = ExperimentManager(self.experiments_dir.parent / "recent_experiments.json")
         self._refresh_recent()
@@ -330,7 +339,8 @@ class StartupDialog(QDialog):
 
     def _show_options_for_path(self, path: str, options_button: QPushButton | None) -> None:
         menu = QMenu(self)
-        menu.addAction("Delete", lambda: self._remove_from_list_for_path(path))
+        if not self._public_mode:
+            menu.addAction("Delete", lambda: self._remove_from_list_for_path(path))
         menu.addAction("Export", lambda: self._export_for_path(path))
         menu.addAction("Show file location", lambda: self._show_file_location(path))
 
@@ -361,6 +371,9 @@ class StartupDialog(QDialog):
         QDesktopServices.openUrl(QUrl.fromLocalFile(parent_dir))
 
     def _start_new(self) -> None:
+        if self._public_mode:
+            QMessageBox.information(self, "Public User", "The Public User cannot create experiments.")
+            return
         dlg = NewExperimentDialog(self.experiments_dir, self)
         if dlg.exec() == QDialog.Accepted and dlg.output_path:
             exp = self.manager.create_new_experiment(dlg.metadata)
@@ -375,6 +388,9 @@ class StartupDialog(QDialog):
             self.accept()
 
     def _load_existing(self) -> None:
+        if self._public_mode:
+            QMessageBox.information(self, "Public User", "The Public User cannot load arbitrary experiment files.")
+            return
         file_path, _ = QFileDialog.getOpenFileName(
             self,
             "Open Experiment",
@@ -429,17 +445,20 @@ class StartupDialog(QDialog):
 
         menu = QMenu(self)
         open_action = menu.addAction("Open")
-        delete_action = menu.addAction("Delete from List")
-        delete_file_action = menu.addAction("Delete File and Remove from List")
+        delete_action = None
+        delete_file_action = None
+        if not self._public_mode:
+            delete_action = menu.addAction("Delete from List")
+            delete_file_action = menu.addAction("Delete File and Remove from List")
         export_action = menu.addAction("Export")
 
         action = menu.exec(self.recent_list.mapToGlobal(position))
 
         if action == open_action:
             self._open_recent(item)
-        elif action == delete_action:
+        elif delete_action is not None and action == delete_action:
             self._delete_experiment(item, delete_file=False)
-        elif action == delete_file_action:
+        elif delete_file_action is not None and action == delete_file_action:
             self._delete_experiment(item, delete_file=True)
         elif action == export_action:
             self._export_experiment(item)

--- a/src/ui/user_selection_dialog.py
+++ b/src/ui/user_selection_dialog.py
@@ -16,8 +16,6 @@ import shutil
 from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
-
-from ui.public_user_dialog import PUBLIC_USER_NAME
 from PySide6.QtWidgets import (
     QDialog,
     QFrame,
@@ -33,6 +31,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from ui.public_user_dialog import PUBLIC_USER_NAME
 
 # ---------------------------------------------------------------------------
 # Public helper (used by StartupDialog and MainWindow for the badge label)

--- a/src/ui/user_selection_dialog.py
+++ b/src/ui/user_selection_dialog.py
@@ -506,6 +506,8 @@ class UserSelectionDialog(QDialog):
         self.accept()
 
     def _on_delete_user(self, user_name: str) -> None:
+        if user_name == PUBLIC_USER_NAME:
+            return
         dlg = _DeleteConfirmDialog(user_name, self)
         if dlg.exec() != QDialog.Accepted:
             return

--- a/src/ui/user_selection_dialog.py
+++ b/src/ui/user_selection_dialog.py
@@ -16,6 +16,8 @@ import shutil
 from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
+
+from ui.public_user_dialog import PUBLIC_USER_NAME
 from PySide6.QtWidgets import (
     QDialog,
     QFrame,
@@ -199,7 +201,7 @@ class _UserCard(QFrame):
         name_lbl.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         name_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
-        # Delete button overlaid at top-right
+        # Delete button overlaid at top-right (hidden for the Public User — it is permanent)
         self._del_btn = QToolButton(self)
         self._del_btn.setText("✕")
         self._del_btn.setFixedSize(22, 22)
@@ -207,6 +209,8 @@ class _UserCard(QFrame):
         self._del_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         self._del_btn.move(_CARD_W - 26, 4)
         self._del_btn.clicked.connect(lambda: self.delete_requested.emit(self._user_name))
+        if user_name == PUBLIC_USER_NAME:
+            self._del_btn.setVisible(False)
 
         inner = QVBoxLayout(self)
         inner.setContentsMargins(8, 16, 8, 12)

--- a/src/ui/workflow.py
+++ b/src/ui/workflow.py
@@ -431,6 +431,15 @@ class WorkflowStepper(QFrame):
             self._manager.mark_step_ready(WorkflowStep.ALIGN_IMAGES)
             self._manager.complete_current_step()
 
+    def set_read_only(self, enabled: bool) -> None:
+        """Lock all workflow navigation buttons (used by Public User mode)."""
+        if not enabled:
+            return
+        from ui.public_user_dialog import ReadOnlyGuard
+        for btn in self._step_buttons.values():
+            ReadOnlyGuard.lock(btn)
+        ReadOnlyGuard.lock(self._next_button)
+
     # ------------------------------------------------------------------
     # UI refresh helpers
     # ------------------------------------------------------------------

--- a/src/ui/workflow.py
+++ b/src/ui/workflow.py
@@ -324,6 +324,8 @@ class WorkflowStepper(QFrame):
         super().__init__(parent)
         self._manager = manager
         self._step_buttons: dict[WorkflowStep, QToolButton] = {}
+        self._read_only_enabled = False
+        self._read_only_guards: list[tuple[QWidget, object]] = []
 
         self.setFrameShape(QFrame.NoFrame)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
@@ -432,13 +434,34 @@ class WorkflowStepper(QFrame):
             self._manager.complete_current_step()
 
     def set_read_only(self, enabled: bool) -> None:
-        """Lock all workflow navigation buttons (used by Public User mode)."""
-        if not enabled:
+        """Lock/unlock workflow navigation buttons (used by Public User mode)."""
+        if enabled == self._read_only_enabled:
             return
+
+        if not enabled:
+            for widget, guard in self._read_only_guards:
+                try:
+                    widget.removeEventFilter(guard)  # type: ignore[arg-type]
+                except Exception:
+                    pass
+            self._read_only_guards.clear()
+            self._read_only_enabled = False
+            self._refresh()
+            return
+
         from ui.public_user_dialog import ReadOnlyGuard
+
+        def _lock(w: QWidget) -> None:
+            try:
+                guard = ReadOnlyGuard.lock(w)
+                self._read_only_guards.append((w, guard))
+            except Exception:
+                pass
+
         for btn in self._step_buttons.values():
-            ReadOnlyGuard.lock(btn)
-        ReadOnlyGuard.lock(self._next_button)
+            _lock(btn)
+        _lock(self._next_button)
+        self._read_only_enabled = True
 
     # ------------------------------------------------------------------
     # UI refresh helpers

--- a/tests/test_alignment_worker.py
+++ b/tests/test_alignment_worker.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from PySide6.QtWidgets import QApplication
 
+import ui.alignment_worker as alignment_worker
 from ui.alignment_worker import AlignmentWorker
 
 
@@ -334,3 +335,271 @@ def test_run_emits_progress_signals(mock_sr_cls: MagicMock, qapp: QApplication) 
     w.run()
 
     assert progress_hits  # At least one progress signal emitted
+
+
+@patch("ui.alignment_worker.ProcessPoolExecutor")
+@patch("pystackreg.StackReg")
+def test_run_parallel_register_and_transform(
+    mock_sr_cls: MagicMock, mock_pool_cls: MagicMock, monkeypatch: pytest.MonkeyPatch, qapp: QApplication
+) -> None:
+    """Large stacks use the process pool when not frozen (mocked executor)."""
+    monkeypatch.setattr(alignment_worker, "_FROZEN", False)
+    monkeypatch.setattr(alignment_worker, "as_completed", lambda pending: list(pending))
+
+    mock_sr = MagicMock()
+    mock_sr_cls.return_value = mock_sr
+
+    exec_inst = MagicMock()
+    mock_pool_cls.return_value = exec_inst
+
+    reg_futures: list[MagicMock] = []
+    xform_futures: list[MagicMock] = []
+    for _ in range(11):
+        f = MagicMock()
+        f.result.return_value = np.eye(3, dtype=np.float64)
+        reg_futures.append(f)
+    for _ in range(12):
+        f = MagicMock()
+        f.result.return_value = np.zeros((4, 4), dtype=np.float64)
+        xform_futures.append(f)
+
+    def _submit(fn, *args, **kwargs):
+        if fn is alignment_worker._register_pair:
+            return reg_futures.pop(0)
+        if fn is alignment_worker._transform_frame:
+            return xform_futures.pop(0)
+        raise AssertionError(f"unexpected fn {fn!r}")
+
+    exec_inst.submit.side_effect = _submit
+
+    stack = np.ones((12, 4, 4), dtype=np.uint16) * 90
+    w = AlignmentWorker(stack, reference="first", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    error_args: list[str] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.error.connect(lambda e: error_args.append(e))
+
+    w.run()
+
+    assert not error_args
+    assert len(finished_args) == 1
+    exec_inst.shutdown.assert_called()
+
+
+@patch("ui.alignment_worker.ProcessPoolExecutor")
+@patch("pystackreg.StackReg")
+def test_run_parallel_mean_reference(
+    mock_sr_cls: MagicMock, mock_pool_cls: MagicMock, monkeypatch: pytest.MonkeyPatch, qapp: QApplication
+) -> None:
+    """Parallel registration supports ``reference='mean'`` (mean stack projection)."""
+    monkeypatch.setattr(alignment_worker, "_FROZEN", False)
+    monkeypatch.setattr(alignment_worker, "as_completed", lambda pending: list(pending))
+
+    mock_sr = MagicMock()
+    mock_sr_cls.return_value = mock_sr
+
+    exec_inst = MagicMock()
+    mock_pool_cls.return_value = exec_inst
+
+    reg_futures: list[MagicMock] = []
+    xform_futures: list[MagicMock] = []
+    for _ in range(11):
+        f = MagicMock()
+        f.result.return_value = np.eye(3, dtype=np.float64)
+        reg_futures.append(f)
+    for _ in range(12):
+        f = MagicMock()
+        f.result.return_value = np.zeros((4, 4), dtype=np.float64)
+        xform_futures.append(f)
+
+    def _submit(fn, *args, **kwargs):
+        if fn is alignment_worker._register_pair:
+            return reg_futures.pop(0)
+        if fn is alignment_worker._transform_frame:
+            return xform_futures.pop(0)
+        raise AssertionError(f"unexpected fn {fn!r}")
+
+    exec_inst.submit.side_effect = _submit
+
+    stack = np.ones((12, 4, 4), dtype=np.uint16) * 40
+    w = AlignmentWorker(stack, reference="mean", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    assert len(finished_args) == 1
+
+
+@patch("ui.alignment_worker.ProcessPoolExecutor")
+@patch("pystackreg.StackReg")
+def test_run_parallel_executor_shutdown_without_cancel_futures_kw(
+    mock_sr_cls: MagicMock, mock_pool_cls: MagicMock, monkeypatch: pytest.MonkeyPatch, qapp: QApplication
+) -> None:
+    """``shutdown(..., cancel_futures=True)`` falls back on older executor APIs."""
+    monkeypatch.setattr(alignment_worker, "_FROZEN", False)
+    monkeypatch.setattr(alignment_worker, "as_completed", lambda pending: list(pending))
+
+    mock_sr = MagicMock()
+    mock_sr_cls.return_value = mock_sr
+
+    exec_inst = MagicMock()
+    mock_pool_cls.return_value = exec_inst
+    attempts = {"n": 0}
+
+    def _shutdown(*a, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise TypeError
+        return None
+
+    exec_inst.shutdown.side_effect = _shutdown
+
+    reg_futures = [MagicMock() for _ in range(11)]
+    for f in reg_futures:
+        f.result.return_value = np.eye(3, dtype=np.float64)
+    xform_futures = [MagicMock() for _ in range(12)]
+    for f in xform_futures:
+        f.result.return_value = np.zeros((4, 4), dtype=np.float64)
+    all_futures = reg_futures + xform_futures
+    idx = {"i": 0}
+
+    def _submit(fn, *args, **kwargs):
+        f = all_futures[idx["i"]]
+        idx["i"] += 1
+        return f
+
+    exec_inst.submit.side_effect = _submit
+
+    stack = np.ones((12, 4, 4), dtype=np.uint16) * 3
+    w = AlignmentWorker(stack, reference="first", enable_multiprocessing=False)
+    w.run()
+
+    assert attempts["n"] == 2
+
+
+@patch("pystackreg.StackReg")
+def test_run_mean_reference_full_pipeline(mock_sr_cls: MagicMock, qapp: QApplication) -> None:
+    mock_sr = MagicMock()
+    mock_sr.register.return_value = np.eye(3, dtype=np.float64)
+    mock_sr.transform.return_value = np.zeros((4, 4), dtype=np.float64)
+    mock_sr_cls.return_value = mock_sr
+
+    stack = np.ones((4, 4, 4), dtype=np.uint16) * 55
+    w = AlignmentWorker(stack, reference="mean", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    assert len(finished_args) == 1
+    _, _, scores = finished_args[0]
+    assert len(scores) == 4
+
+
+@patch("pystackreg.StackReg")
+def test_run_custom_reference_uses_register_stack(mock_sr_cls: MagicMock, qapp: QApplication) -> None:
+    mock_sr = MagicMock()
+    mock_sr.register_stack.return_value = np.tile(np.eye(3), (3, 1, 1))
+    mock_sr.transform.return_value = np.zeros((4, 4), dtype=np.float64)
+    mock_sr_cls.return_value = mock_sr
+
+    stack = np.ones((3, 4, 4), dtype=np.uint16) * 12
+    w = AlignmentWorker(stack, reference="third", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    assert len(finished_args) == 1
+    mock_sr.register_stack.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "transform_type",
+    ["translation", "scaled_rotation", "affine", "bilinear", "RIGID_BODY", "not_a_mapped_mode"],
+)
+@patch("pystackreg.StackReg")
+def test_run_accepts_transform_type_strings(mock_sr_cls: MagicMock, transform_type: str, qapp: QApplication) -> None:
+    mock_sr = MagicMock()
+    mock_sr.register.return_value = np.eye(3, dtype=np.float64)
+    mock_sr.transform.return_value = np.zeros((4, 4), dtype=np.float64)
+    mock_sr_cls.return_value = mock_sr
+
+    stack = np.ones((2, 4, 4), dtype=np.uint16) * 77
+    w = AlignmentWorker(stack, transform_type=transform_type, reference="first", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    assert len(finished_args) == 1
+    mock_sr_cls.assert_called_once()
+
+
+@patch("pystackreg.StackReg")
+def test_run_uint8_stack_denormalizes_to_uint8(mock_sr_cls: MagicMock, qapp: QApplication) -> None:
+    mock_sr = MagicMock()
+    mock_sr.register.return_value = np.eye(3, dtype=np.float64)
+    mock_sr.transform.return_value = np.zeros((4, 4), dtype=np.float64)
+    mock_sr_cls.return_value = mock_sr
+
+    stack = np.array([[[10, 20], [30, 40]], [[50, 60], [70, 80]]], dtype=np.uint8)
+    w = AlignmentWorker(stack, reference="first", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    aligned, _, _ = finished_args[0]
+    assert aligned.dtype == np.uint8
+
+
+@patch("pystackreg.StackReg")
+def test_run_float_stack_preserves_float_dtype(mock_sr_cls: MagicMock, qapp: QApplication) -> None:
+    mock_sr = MagicMock()
+    mock_sr.register.return_value = np.eye(3, dtype=np.float64)
+    mock_sr.transform.return_value = np.zeros((4, 4), dtype=np.float64)
+    mock_sr_cls.return_value = mock_sr
+
+    stack = np.ones((2, 4, 4), dtype=np.float32) * 0.25
+    w = AlignmentWorker(stack, reference="first", enable_multiprocessing=False)
+
+    finished_args: list[tuple] = []
+    w.finished.connect(lambda a, b, c: finished_args.append((a, b, c)))
+    w.run()
+
+    aligned, _, _ = finished_args[0]
+    assert aligned.dtype == np.float32
+
+
+def test_register_parallel_cancel_returns_none(qapp: QApplication) -> None:
+    w = AlignmentWorker(np.ones((5, 3, 3), dtype=np.uint16), reference="first")
+    exec_mock = MagicMock()
+    fut = MagicMock()
+
+    def _boom(*a, **k):
+        w.request_cancel()
+        return fut
+
+    exec_mock.submit.side_effect = _boom
+    fut.result.return_value = np.eye(3)
+
+    assert w._register_parallel(exec_mock, np.ones((5, 3, 3), dtype=np.uint16), 0, 5) is None
+
+
+def test_transform_parallel_cancel_returns_none(qapp: QApplication) -> None:
+    w = AlignmentWorker(np.ones((3, 3, 3), dtype=np.uint16))
+    exec_mock = MagicMock()
+    fut = MagicMock()
+
+    def _boom(*a, **k):
+        w.request_cancel()
+        return fut
+
+    exec_mock.submit.side_effect = _boom
+    fut.result.return_value = np.zeros((3, 3), dtype=np.float64)
+    tmats = np.tile(np.eye(3), (3, 1, 1))
+
+    assert w._transform_parallel(exec_mock, np.ones((3, 3, 3), dtype=np.uint16), tmats, 0, 3) is None

--- a/tests/test_circular_stats.py
+++ b/tests/test_circular_stats.py
@@ -14,6 +14,9 @@ from core.circular_stats import (
     rayleigh_test,
 )
 
+# En dash (U+2013), same as ``p_value`` strings in ``rao_spacing_test``.
+_EN = "\u2013"
+
 
 class TestRaoTableHelpers:
     def test_row_index_too_small_raises(self) -> None:
@@ -29,7 +32,37 @@ class TestRaoTableHelpers:
             (31, 27),
             (32, 27),
             (33, 28),
+            (37, 28),
+            (38, 29),
+            (42, 29),
+            (43, 30),
+            (47, 30),
+            (48, 31),
+            (62, 31),
+            (63, 32),
+            (87, 32),
+            (88, 33),
             (100, 33),
+            (125, 33),
+            (126, 34),
+            (175, 34),
+            (176, 35),
+            (250, 35),
+            (251, 36),
+            (350, 36),
+            (351, 37),
+            (450, 37),
+            (451, 38),
+            (550, 38),
+            (551, 39),
+            (650, 39),
+            (651, 40),
+            (750, 40),
+            (751, 41),
+            (850, 41),
+            (851, 42),
+            (950, 42),
+            (951, 43),
             (2000, 43),
         ],
     )
@@ -68,6 +101,57 @@ class TestRaoSpacingTest:
         out = rao_spacing_test(np.array([-10.0, 350.0, 90.0, 170.0]))
         assert out["n"] == 4
         assert "U" in out and "p_value" in out
+
+    @pytest.mark.parametrize(
+        ("angles", "expected_p"),
+        [
+            (
+                np.array([80.05400156, 83.93890403, 85.61343119, 70.89509776]),
+                f"0.001{_EN}0.01",
+            ),
+            (
+                np.array([335.94132899, 308.50075145, 299.17665529, 312.64366824]),
+                f"0.01{_EN}0.05",
+            ),
+            (
+                np.array([212.29210324, 241.03198121, 240.88589861, 188.29791919]),
+                f"0.05{_EN}0.10",
+            ),
+            (
+                np.array(
+                    [
+                        72.04410608,
+                        102.97287205,
+                        69.37785702,
+                        66.13046044,
+                        84.41640955,
+                        67.14665021,
+                        57.45546007,
+                        95.5375559,
+                    ]
+                ),
+                f"0.001{_EN}0.01",
+            ),
+            (
+                np.array(
+                    [
+                        322.56824591,
+                        117.79625267,
+                        342.09789341,
+                        322.48479507,
+                        350.66220465,
+                        346.05477035,
+                        114.08056131,
+                        337.76591354,
+                    ]
+                ),
+                f"0.05{_EN}0.10",
+            ),
+        ],
+    )
+    def test_p_value_brackets(self, angles: np.ndarray, expected_p: str) -> None:
+        out = rao_spacing_test(angles)
+        assert out["p_value"] == expected_p
 
 
 class TestRayleighTest:

--- a/tests/test_data_analyzer.py
+++ b/tests/test_data_analyzer.py
@@ -67,3 +67,38 @@ def test_extract_roi_intensity_time_series_validates_dimensions():
     analyzer = _make_analyzer()
     with pytest.raises(ValueError, match="must be a 3D array"):
         analyzer.extract_roi_intensity_time_series(np.zeros((4, 4)))
+
+
+def test_generate_plots_hist_and_line():
+    analyzer = _make_analyzer()
+    data = np.array([1.0, 2.0, 3.0])
+    fig1 = analyzer.generate_plots(data, plot_type="hist")
+    fig2 = analyzer.generate_plots(data, plot_type="line")
+    assert fig1 is not None and fig2 is not None
+
+
+def test_save_results_to_experiment_appends_run():
+    analyzer = _make_analyzer()
+    exp = Experiment(name="x")
+    analyzer.save_results_to_experiment(exp)
+    assert exp.analysis_results["runs"]
+
+
+def test_time_series_and_correlation_stubs():
+    analyzer = _make_analyzer()
+    assert analyzer.time_series_analysis(np.array([1.0])) == {}
+    assert analyzer.correlation_analysis(np.array([1.0]), np.array([2.0])) == {}
+
+
+def test_extract_roi_intensity_legacy_missing_rect_returns_zeros():
+    analyzer = _make_analyzer()
+    frames = np.zeros((2, 4, 4), dtype=np.float32)
+    out = analyzer.extract_roi_intensity_time_series(frames, roi=None)
+    assert out.tolist() == [0.0, 0.0]
+
+
+def test_extract_roi_intensity_legacy_empty_rect_returns_zeros():
+    analyzer = _make_analyzer()
+    frames = np.zeros((2, 4, 4), dtype=np.float32)
+    out = analyzer.extract_roi_intensity_time_series(frames, roi=None, roi_x=2, roi_y=2, roi_width=0, roi_height=2)
+    assert out.tolist() == [0.0, 0.0]

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 
@@ -149,3 +150,119 @@ def test_remove_from_recent_removes_entry(tmp_path: Path, recent_file: Path) -> 
     mgr.remove_from_recent(path)
     payload = json.loads(recent_file.read_text(encoding="utf-8"))
     assert payload["recent"] == []
+
+
+def test_delete_experiment_removes_disk_file_when_requested(tmp_path: Path, recent_file: Path) -> None:
+    mgr = ExperimentManager()
+    path = tmp_path / "gone.nexp"
+    path.write_text("{}", encoding="utf-8")
+    resolved = str(path.resolve())
+    mgr.add_to_recent(resolved, "Gone")
+    assert mgr.delete_experiment(resolved, delete_file=True) is True
+    assert not path.is_file()
+    assert json.loads(recent_file.read_text(encoding="utf-8"))["recent"] == []
+
+
+def test_delete_experiment_returns_false_when_recent_update_fails(
+    tmp_path: Path, recent_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mgr = ExperimentManager()
+    path = tmp_path / "x.nexp"
+    path.write_text("{}", encoding="utf-8")
+
+    def _boom(_p: str) -> None:
+        raise OSError("recent unavailable")
+
+    monkeypatch.setattr(mgr, "remove_from_recent", _boom)
+    assert mgr.delete_experiment(str(path.resolve()), delete_file=False) is False
+
+
+def test_add_to_recent_swallows_oserror_on_write(
+    tmp_path: Path, recent_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mgr = ExperimentManager()
+    phantom = tmp_path / "phantom.nexp"
+    phantom.write_text("{}", encoding="utf-8")
+    real_open = builtins.open
+    recent_resolved = recent_file.resolve()
+
+    def _open(path, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if mode == "w" and Path(path).resolve() == recent_resolved:
+            raise OSError("disk full")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _open)
+    mgr.add_to_recent(str(phantom.resolve()), "P")
+
+
+def test_from_json_adds_utc_to_naive_timestamps() -> None:
+    data = {
+        "version": "1.0",
+        "experiment": {
+            "name": "T",
+            "created_date": "2020-01-01T00:00:00",
+            "modified_date": "2020-01-02T12:00:00",
+            "image_stack": {"path": "", "file_list": [], "count": 0},
+        },
+    }
+    exp = Experiment.from_json(data)
+    assert exp.created_date.tzinfo is not None
+    assert exp.modified_date.tzinfo is not None
+
+
+def test_serialize_neuron_detection_missing_or_invalid_payload() -> None:
+    exp = Experiment(name="x")
+    assert exp._serialize_neuron_detection() is None
+    exp._neuron_detection_data = None  # type: ignore[assignment]
+    assert exp._serialize_neuron_detection() is None
+    exp._neuron_detection_data = "not-a-dict"  # type: ignore[assignment]
+    assert exp._serialize_neuron_detection() is None
+
+
+def test_serialize_neuron_detection_empty_inner_dict() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {}
+    assert exp._serialize_neuron_detection() is None
+
+
+def test_serialize_neuron_detection_locations_non_ndarray_branch() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {"neuron_locations": [[1, 2], [3, 4]]}
+    out = exp._serialize_neuron_detection()
+    assert out is not None
+    assert out["neuron_locations"] == [[1, 2], [3, 4]]
+
+
+def test_serialize_neuron_detection_skips_empty_numpy_arrays() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {
+        "neuron_locations": np.array([], dtype=np.int32).reshape(0, 2),
+        "neuron_trajectories": np.array([], dtype=np.float32).reshape(0, 3),
+        "quality_mask": np.array([], dtype=bool),
+    }
+    assert exp._serialize_neuron_detection() is None
+
+
+def test_serialize_neuron_detection_trajectories_list_fallback() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {"neuron_trajectories": [[1.0, 2.0]]}
+    out = exp._serialize_neuron_detection()
+    assert out is not None
+    assert out["neuron_trajectories"] == [[1.0, 2.0]]
+
+
+def test_serialize_neuron_detection_quality_mask_list() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {"quality_mask": [True, False]}
+    out = exp._serialize_neuron_detection()
+    assert out is not None
+    assert out["quality_mask"] == [True, False]
+
+
+def test_serialize_neuron_detection_roi_origin_tuple() -> None:
+    exp = Experiment(name="x")
+    exp._neuron_detection_data = {"roi_origin": (0, 1, 1)}
+    out = exp._serialize_neuron_detection()
+    assert out is not None
+    assert out["roi_origin"] == [0, 1, 1]

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import tifffile
+from PIL import Image
 
 from core.experiment_manager import Experiment
-from utils.file_handler import ImageStackHandler, _extract_valid_time
+from utils.file_handler import ImageStackHandler, _extract_valid_time, _get_exif_timestamp
 
 
 def test_load_stack_from_list_filters_non_tiff(tmp_path: Path) -> None:
@@ -190,3 +193,122 @@ def test_get_all_frames_as_array_empty_range(tmp_path: Path) -> None:
 )
 def test_extract_valid_time_normalizes_and_validates(raw, expected) -> None:
     assert _extract_valid_time(raw) == expected
+
+
+def test_extract_valid_time_bytes_decode_error_returns_none() -> None:
+    raw = MagicMock(spec=bytes)
+    raw.decode.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "x")
+    assert _extract_valid_time(raw) is None
+
+
+def test_get_included_files_invalid_range_returns_empty() -> None:
+    h = ImageStackHandler()
+    h.files = ["/a.tif", "/b.tif"]
+    h.set_included_range(2, 0)
+    assert h.get_included_files() == []
+
+
+def test_get_image_at_index_tiff_fallback_pillow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "x.tif"
+    tifffile.imwrite(path, np.ones((2, 2), dtype=np.uint8))
+    h = ImageStackHandler()
+    h.files = [str(path)]
+
+    def _boom(*_a, **_k):
+        raise OSError("tifffile read failed")
+
+    monkeypatch.setattr(tifffile, "imread", _boom)
+    img = h.get_image_at_index(0)
+    assert img.shape == (2, 2)
+
+
+def test_get_all_frames_uses_thread_pool_for_multiple_files(tmp_path: Path) -> None:
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"{i}.tif"
+        tifffile.imwrite(p, np.full((2, 2), i, dtype=np.uint8))
+        paths.append(str(p))
+    h = ImageStackHandler()
+    h.load_image_stack(paths)
+    stack = h.get_all_frames_as_array()
+    assert stack is not None
+    assert stack.shape[0] == 3
+
+
+def test_associate_with_experiment_sets_start_time_from_exif(tmp_path: Path) -> None:
+    path = tmp_path / "m.tif"
+    Image.fromarray(np.zeros((4, 4), dtype=np.uint8)).save(path, format="TIFF")
+    h = ImageStackHandler()
+    h.files = [str(path)]
+    exp = Experiment(name="E")
+    with patch("utils.file_handler._get_exif_timestamp", return_value="12:34:56"):
+        h.associate_with_experiment(exp)
+    assert exp.settings["acquisition"]["experiment_start_time"] == "12:34:56"
+
+
+def test_associate_skips_exif_when_start_time_already_set(tmp_path: Path) -> None:
+    path = tmp_path / "m.tif"
+    Image.fromarray(np.zeros((4, 4), dtype=np.uint8)).save(path, format="TIFF")
+    h = ImageStackHandler()
+    h.files = [str(path)]
+    exp = Experiment(name="E")
+    exp.settings["acquisition"] = {"experiment_start_time": "01:02:03"}
+    with patch("utils.file_handler._get_exif_timestamp", return_value="99:99:99"):
+        h.associate_with_experiment(exp)
+    assert exp.settings["acquisition"]["experiment_start_time"] == "01:02:03"
+
+
+def test_associate_creates_acquisition_when_non_dict(tmp_path: Path) -> None:
+    path = tmp_path / "m.tif"
+    Image.fromarray(np.zeros((4, 4), dtype=np.uint8)).save(path, format="TIFF")
+    h = ImageStackHandler()
+    h.files = [str(path)]
+    exp = Experiment(name="E")
+    exp.settings["acquisition"] = "broken"  # type: ignore[assignment]
+    with patch("utils.file_handler._get_exif_timestamp", return_value="08:00:00"):
+        h.associate_with_experiment(exp)
+    assert isinstance(exp.settings["acquisition"], dict)
+    assert exp.settings["acquisition"]["experiment_start_time"] == "08:00:00"
+
+
+def test_get_exif_timestamp_handles_pil_and_tifffile_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "empty.tif"
+    path.write_bytes(b"not a real tif")
+    assert _get_exif_timestamp(str(path)) is None
+
+
+def test_get_all_frames_single_file_sequential_load(tmp_path: Path) -> None:
+    p = tmp_path / "one.tif"
+    tifffile.imwrite(p, np.zeros((2, 2), dtype=np.uint8))
+    h = ImageStackHandler()
+    h.load_image_stack([str(p)])
+    stack = h.get_all_frames_as_array()
+    assert stack is not None and stack.shape == (1, 2, 2)
+
+
+def test_get_exif_timestamp_reads_datetimeoriginal_from_pil_exif(tmp_path: Path) -> None:
+    path = tmp_path / "meta.tif"
+    path.write_bytes(b"x")
+    mock_img = MagicMock()
+    mock_img.__enter__.return_value = mock_img
+    mock_img.__exit__.return_value = None
+    mock_img._getexif.return_value = {36867: "2024:03:15 09:08:07"}
+    with patch("utils.file_handler.Image.open", return_value=mock_img):
+        assert _get_exif_timestamp(str(path)) == "09:08:07"
+
+
+def test_get_all_frames_falls_back_when_thread_pool_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"{i}.tif"
+        tifffile.imwrite(p, np.full((2, 2), i, dtype=np.uint8))
+        paths.append(str(p))
+    monkeypatch.setattr(
+        concurrent.futures,
+        "ThreadPoolExecutor",
+        MagicMock(side_effect=RuntimeError("executor unavailable")),
+    )
+    h = ImageStackHandler()
+    h.load_image_stack(paths)
+    stack = h.get_all_frames_as_array()
+    assert stack is not None and stack.shape == (2, 2, 2)

--- a/tests/test_help_widgets.py
+++ b/tests/test_help_widgets.py
@@ -1,0 +1,23 @@
+"""Tests for help tooltip helpers and fallback help text."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ui.help_content import get_help_text
+from ui.help_widgets import HelpIconButton
+
+
+def test_get_help_text_unknown_id_returns_fallback() -> None:
+    text = get_help_text("__no_such_help_id__")
+    assert "not available" in text.lower()
+
+
+def test_help_icon_button_click_shows_tooltip() -> None:
+    btn = HelpIconButton("workflow.overview", tooltip="Custom tip")
+    with patch("ui.help_widgets.QToolTip.showText") as show:
+        btn._show_tooltip_now()
+        show.assert_called_once()
+        _, tip, w = show.call_args[0]
+        assert tip == "Custom tip"
+        assert w is btn

--- a/tests/test_image_viewer_lru_cache.py
+++ b/tests/test_image_viewer_lru_cache.py
@@ -1,0 +1,40 @@
+"""Tests for ``ImageViewer``'s internal frame cache (LRU)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ui.image_viewer import _LRUCache
+
+
+def test_lru_cache_get_moves_key_to_most_recent() -> None:
+    c = _LRUCache(capacity=2)
+    a = np.array([1])
+    b = np.array([2])
+    c.set(0, a)
+    c.set(1, b)
+    assert c.get(0) is a
+    # Key 0 should now be MRU; inserting 2 evicts key 1 (was LRU)
+    c.set(2, np.array([3]))
+    assert c.get(1) is None
+    assert c.get(0) is not None
+    assert c.get(2) is not None
+
+
+def test_lru_cache_set_replaces_existing_key_without_eviction() -> None:
+    c = _LRUCache(capacity=2)
+    c.set(0, np.array([0]))
+    c.set(1, np.array([1]))
+    c.set(0, np.array([10]))
+    assert c.get(0)[0] == 10
+    assert c.get(1) is not None
+
+
+def test_lru_cache_evicts_oldest_when_at_capacity() -> None:
+    c = _LRUCache(capacity=2)
+    c.set(0, np.zeros(1))
+    c.set(1, np.ones(1))
+    c.set(2, np.full(1, 2.0))
+    assert c.get(0) is None
+    assert np.allclose(c.get(1), [1.0])
+    assert np.allclose(c.get(2), [2.0])

--- a/tests/test_lomb_scargle_core.py
+++ b/tests/test_lomb_scargle_core.py
@@ -86,3 +86,15 @@ def test_compute_lomb_scargle_discards_nonfinite_samples():
 
     assert out["n_samples"] == int(mask.sum())
     assert out["frequency"].size == 100
+
+
+def test_compute_lomb_scargle_nonfinite_power_raises(monkeypatch):
+    t = np.linspace(0.0, 10.0, 50)
+    y = np.sin(2.0 * np.pi * 0.5 * t)
+
+    def _bad_lomb(_t, _y, angular_freq, **kwargs):
+        return np.full(angular_freq.shape[0], np.nan, dtype=float)
+
+    monkeypatch.setattr("core.lomb_scargle.lombscargle", _bad_lomb)
+    with pytest.raises(RuntimeError, match="non-finite power"):
+        compute_lomb_scargle(t, y, min_freq=0.01, max_freq=1.0, num_freqs=20)

--- a/tests/test_main_launcher.py
+++ b/tests/test_main_launcher.py
@@ -1,0 +1,178 @@
+"""Tests for ``main.main()`` launcher behavior (Public User sync on login)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QDialog
+
+from core.experiment_manager import Experiment
+
+
+class _FakeApp:
+    def __init__(self, *a, **k) -> None:
+        pass
+
+    def setWindowIcon(self, *a, **k) -> None:
+        pass
+
+    def setStyleSheet(self, *a, **k) -> None:
+        pass
+
+    def exec(self) -> int:
+        return 0
+
+
+def test_main_calls_sync_when_public_user_logs_in(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    sync_calls: list[int] = []
+    monkeypatch.setattr("main.sync_public_experiments", lambda: sync_calls.append(1))
+    monkeypatch.setattr("main.ensure_public_user_exists", lambda: None)
+
+    pub_exp = tmp_path / "users" / "Public" / "experiments"
+    pub_exp.mkdir(parents=True)
+
+    class _UserDlg:
+        selected_user_experiments_dir = pub_exp
+        selected_user = "Public"
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    exp_path = str(tmp_path / "e.nexp")
+
+    class _StartupDlg:
+        Accepted = QDialog.Accepted
+
+        def __init__(self, *a, **k) -> None:
+            self.experiment = Experiment(name="E")
+            self.experiment_path = exp_path
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    mw = MagicMock()
+    timer_instance = MagicMock()
+
+    monkeypatch.setattr("main.QApplication", _FakeApp)
+    monkeypatch.setattr("main.UserSelectionDialog", lambda *a, **k: _UserDlg())
+    monkeypatch.setattr("main.StartupDialog", _StartupDlg)
+    monkeypatch.setattr("main.MainWindow", lambda *a, **k: mw)
+    monkeypatch.setattr("main.get_theme", lambda: "light")
+    monkeypatch.setattr("main.get_stylesheet", lambda _theme: "")
+    monkeypatch.setattr("main.QTimer", lambda: timer_instance)
+
+    import main as main_mod
+
+    assert main_mod.main() == 0
+    assert sync_calls == [1]
+    mw.show.assert_called_once()
+    timer_instance.start.assert_called_once()
+
+
+def test_main_does_not_sync_for_non_public_user(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    sync_calls: list[int] = []
+    monkeypatch.setattr("main.sync_public_experiments", lambda: sync_calls.append(1))
+    monkeypatch.setattr("main.ensure_public_user_exists", lambda: None)
+
+    alice_exp = tmp_path / "users" / "alice" / "experiments"
+    alice_exp.mkdir(parents=True)
+
+    class _UserDlg:
+        selected_user_experiments_dir = alice_exp
+        selected_user = "alice"
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    exp_path = str(tmp_path / "e.nexp")
+
+    class _StartupDlg:
+        Accepted = QDialog.Accepted
+
+        def __init__(self, *a, **k) -> None:
+            self.experiment = Experiment(name="E")
+            self.experiment_path = exp_path
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    mw = MagicMock()
+
+    monkeypatch.setattr("main.QApplication", _FakeApp)
+    monkeypatch.setattr("main.UserSelectionDialog", lambda *a, **k: _UserDlg())
+    monkeypatch.setattr("main.StartupDialog", _StartupDlg)
+    monkeypatch.setattr("main.MainWindow", lambda *a, **k: mw)
+    monkeypatch.setattr("main.get_theme", lambda: "light")
+    monkeypatch.setattr("main.get_stylesheet", lambda _theme: "")
+    monkeypatch.setattr("main.QTimer", lambda: MagicMock())
+
+    import main as main_mod
+
+    assert main_mod.main() == 0
+    assert sync_calls == []
+
+
+def test_main_returns_zero_when_user_picks_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("main.ensure_public_user_exists", lambda: None)
+
+    class _UserDlg:
+        def exec(self) -> int:
+            return QDialog.Rejected
+
+    main_cls = MagicMock()
+    monkeypatch.setattr("main.QApplication", _FakeApp)
+    monkeypatch.setattr("main.UserSelectionDialog", lambda *a, **k: _UserDlg())
+    monkeypatch.setattr("main.MainWindow", main_cls)
+    monkeypatch.setattr("main.get_theme", lambda: "light")
+    monkeypatch.setattr("main.get_stylesheet", lambda _theme: "")
+
+    import main as main_mod
+
+    assert main_mod.main() == 0
+    main_cls.assert_not_called()
+
+
+def test_main_swallows_set_current_experiment_path_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Startup may pass a path helper; failures there must not abort launch."""
+    monkeypatch.setattr("main.ensure_public_user_exists", lambda: None)
+    monkeypatch.setattr("main.sync_public_experiments", lambda: None)
+
+    alice_exp = tmp_path / "users" / "alice" / "experiments"
+    alice_exp.mkdir(parents=True)
+
+    class _UserDlg:
+        selected_user_experiments_dir = alice_exp
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    exp_path = str(tmp_path / "e.nexp")
+
+    class _StartupDlg:
+        Accepted = QDialog.Accepted
+
+        def __init__(self, *a, **k) -> None:
+            self.experiment = Experiment(name="E")
+            self.experiment_path = exp_path
+
+        def exec(self) -> int:
+            return QDialog.Accepted
+
+    mw = MagicMock()
+    mw.set_current_experiment_path.side_effect = RuntimeError("path helper unavailable")
+
+    monkeypatch.setattr("main.QApplication", _FakeApp)
+    monkeypatch.setattr("main.UserSelectionDialog", lambda *a, **k: _UserDlg())
+    monkeypatch.setattr("main.StartupDialog", _StartupDlg)
+    monkeypatch.setattr("main.MainWindow", lambda *a, **k: mw)
+    monkeypatch.setattr("main.get_theme", lambda: "light")
+    monkeypatch.setattr("main.get_stylesheet", lambda _theme: "")
+    monkeypatch.setattr("main.QTimer", lambda: MagicMock())
+
+    import main as main_mod
+
+    assert main_mod.main() == 0
+    mw.set_current_experiment_path.assert_called_once()
+    mw.show.assert_called_once()

--- a/tests/test_main_window_autoload.py
+++ b/tests/test_main_window_autoload.py
@@ -1,0 +1,236 @@
+"""Tests for MainWindow._auto_load_experiment_data (stack + ROI + detection restore)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication, QWidget
+
+from core.experiment_manager import Experiment
+from core.roi import ROI
+from ui.main_window import MainWindow
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _make_main_window(
+    experiment: Experiment,
+    *,
+    user_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stack_array: np.ndarray | None,
+) -> MainWindow:
+    """Build MainWindow with heavy UI mocked; QTimer.singleShot runs callbacks immediately."""
+
+    def _immediate_single_shot(_ms: int, fn: object) -> None:
+        assert callable(fn)
+        fn()
+
+    monkeypatch.setattr(QTimer, "singleShot", staticmethod(_immediate_single_shot))
+
+    mock_loading = MagicMock()
+    mock_loading_cls = MagicMock(return_value=mock_loading)
+
+    mock_viewer = QWidget()
+    mock_viewer.index = 0
+    mock_viewer.cache = MagicMock()
+    mock_viewer.current_roi = None
+    mock_viewer.image_label = MagicMock()
+    mock_viewer.filename_label = MagicMock()
+    mock_viewer.slider = MagicMock()
+    mock_viewer.set_stack = MagicMock()
+    mock_viewer.set_roi = MagicMock()
+    mock_viewer.reset = MagicMock()
+    mock_viewer.image_processor = MagicMock()
+    mock_viewer.get_current_roi = MagicMock(return_value=None)
+    mock_viewer.get_exposure = MagicMock(return_value=0)
+    mock_viewer.get_contrast = MagicMock(return_value=0)
+    mock_viewer.stackLoaded = MagicMock()
+    mock_viewer.stackLoaded.connect = MagicMock()
+    mock_viewer.roiSelected = MagicMock()
+    mock_viewer.roiSelected.connect = MagicMock()
+    mock_viewer.roiDeleted = MagicMock()
+    mock_viewer.roiDeleted.connect = MagicMock()
+    mock_viewer.displaySettingsChanged = MagicMock()
+    mock_viewer.displaySettingsChanged.connect = MagicMock()
+    mock_viewer.frameCullingChanged = MagicMock()
+    mock_viewer.frameCullingChanged.connect = MagicMock()
+    mock_viewer.set_filter_excluded = MagicMock()
+    mock_viewer.set_exposure = MagicMock()
+    mock_viewer.set_contrast = MagicMock()
+    mock_viewer.set_cull_range = MagicMock()
+
+    det = MagicMock()
+    det.detectionCompleted = MagicMock()
+    det.detectionCompleted.connect = MagicMock()
+    det.reset_detection_state = MagicMock()
+    det.load_detection_data = MagicMock()
+    det.set_roi_mask = MagicMock()
+    det.set_frame_data = MagicMock()
+    det.set_image_processor = MagicMock()
+
+    mock_roi_plot = MagicMock()
+    mock_traj = MagicMock()
+    mock_lomb = MagicMock()
+    mock_ray = MagicMock()
+
+    mock_analysis = QWidget()
+    mock_analysis.roi_plot_widget = mock_roi_plot
+    mock_analysis.get_roi_plot_widget = MagicMock(return_value=mock_roi_plot)
+    mock_analysis.get_neuron_detection_widget = MagicMock(return_value=det)
+    mock_analysis.get_neuron_trajectory_plot_widget = MagicMock(return_value=mock_traj)
+    mock_analysis.get_lomb_scargle_widget = MagicMock(return_value=mock_lomb)
+    mock_analysis.get_rayleigh_plot_widget = MagicMock(return_value=mock_ray)
+
+    mock_stack_handler = MagicMock()
+    mock_stack_handler.files = []
+    mock_stack_handler.associate_with_experiment = MagicMock()
+    mock_stack_handler.get_all_frames_as_array = MagicMock(return_value=stack_array)
+    mock_stack_handler.get_total_frame_count = MagicMock(return_value=3 if stack_array is not None else 0)
+    mock_stack_handler.set_included_range = MagicMock()
+
+    mock_data_analyzer = MagicMock()
+    mock_data_analyzer.extract_roi_intensity_time_series = MagicMock(
+        return_value=np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    )
+
+    with (
+        patch("ui.main_window.ImageViewer", return_value=mock_viewer),
+        patch("ui.main_window.AnalysisPanel", return_value=mock_analysis),
+        patch("ui.main_window.ImageStackHandler", return_value=mock_stack_handler),
+        patch("ui.main_window.DataAnalyzer", return_value=mock_data_analyzer),
+        patch("ui.main_window.LoadingDialog", mock_loading_cls),
+    ):
+        return MainWindow(experiment, user_experiments_dir=user_dir)
+
+
+def test_auto_load_stack_from_directory_only(app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    img_dir = tmp_path / "stack"
+    img_dir.mkdir()
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = str(img_dir)
+    exp.image_stack_files = []
+
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=None)
+    mw.viewer.set_stack.assert_called_once_with(str(img_dir))
+    mw.viewer.set_roi.assert_not_called()
+
+
+def test_auto_load_stack_from_saved_file_list(app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tif = tmp_path / "a.tif"
+    tif.write_bytes(b"")
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = str(tmp_path)
+    exp.image_stack_files = [str(tif)]
+
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=None)
+    mw.viewer.set_stack.assert_called_once_with([str(tif)])
+
+
+def test_auto_load_fallback_to_directory_when_saved_files_missing(
+    app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = str(fallback)
+    exp.image_stack_files = [str(tmp_path / "missing.tif")]
+
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=None)
+    mw.viewer.set_stack.assert_called_once_with(str(fallback))
+
+
+def test_auto_load_restores_rois_and_detection_data(app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = str(stack_dir)
+    exp.image_stack_files = []
+    exp.rois["roi_1"] = {"x": 0, "y": 0, "width": 4, "height": 4, "shape": "ellipse"}
+
+    locs = np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float64)
+    traj = np.zeros((2, 3, 2), dtype=np.float64)
+    qual = np.array([True, False], dtype=bool)
+    exp.set_neuron_detection_data(
+        neuron_locations=locs,
+        neuron_trajectories=traj,
+        quality_mask=qual,
+        detection_params={"cell_size": 8},
+    )
+
+    frame_data = np.random.default_rng(0).random((3, 8, 8)).astype(np.float32)
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=frame_data)
+
+    det = mw.analysis.get_neuron_detection_widget.return_value
+    assert mw.viewer.set_stack.called
+    assert mw.viewer.set_roi.call_count >= 1
+    det.load_detection_data.assert_called_once()
+    call_kw = det.load_detection_data.call_args[1]
+    assert np.array_equal(call_kw["neuron_locations"], locs)
+
+
+def test_auto_load_detection_only_when_no_stack_path(app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = None
+    locs = np.array([[1.0, 1.0]], dtype=np.float64)
+    exp.set_neuron_detection_data(
+        neuron_locations=locs,
+        neuron_trajectories=np.zeros((1, 2, 2), dtype=np.float64),
+        quality_mask=np.array([True], dtype=bool),
+    )
+
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=None)
+    det = mw.analysis.get_neuron_detection_widget.return_value
+    mw.viewer.set_stack.assert_not_called()
+    det.load_detection_data.assert_called_once()
+
+
+def test_auto_load_roi_from_dict_fallback_on_invalid_polygon_points(
+    app, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ROI.from_dict`` failure uses bounding-box fallback in _auto_load_experiment_data."""
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    user_dir = tmp_path / "users" / "alice" / "experiments"
+    user_dir.mkdir(parents=True)
+
+    exp = Experiment(name="E")
+    exp.image_stack_path = str(stack_dir)
+    exp.rois["roi_1"] = {
+        "shape": "polygon",
+        "points": [["a", "b"], ["c", "d"], ["e", "f"]],
+        "x": 0,
+        "y": 0,
+        "width": 10,
+        "height": 10,
+    }
+
+    frame_data = np.ones((2, 6, 6), dtype=np.float32)
+    mw = _make_main_window(exp, user_dir=user_dir, monkeypatch=monkeypatch, stack_array=frame_data)
+    assert mw.viewer.set_roi.called
+    first_call = mw.viewer.set_roi.call_args_list[0]
+    assert isinstance(first_call[0][0], ROI)

--- a/tests/test_neuron_detection_widget.py
+++ b/tests/test_neuron_detection_widget.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QMessageBox, QWidget
 
 # The test environment does not always install matplotlib, but this widget only
 # needs lightweight stubs for construction in this test.
@@ -20,10 +21,19 @@ class _DummyCanvas(QWidget):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__()
 
+    def draw(self) -> None:
+        pass
+
 
 class _DummyFigure:
     def __init__(self, *args, **kwargs) -> None:
         pass
+
+    def clear(self) -> None:
+        pass
+
+    def add_subplot(self, *args, **kwargs) -> MagicMock:
+        return MagicMock()
 
 
 backend_qtagg_module.FigureCanvasQTAgg = _DummyCanvas
@@ -52,3 +62,221 @@ def test_max_absent_frames_defaults_to_stack_length(qapp: QApplication) -> None:
     assert widget.max_absent_frames_spin.minimum() == 0
     assert widget.max_absent_frames_spin.maximum() == 7
     assert widget.max_absent_frames_spin.value() == 7
+
+
+def test_set_image_processor_assigns(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    proc = MagicMock()
+    w.set_image_processor(proc)
+    assert w.image_processor is proc
+
+
+def test_max_absent_frames_keeps_user_value_when_stack_changes(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.set_frame_data(np.zeros((5, 4, 4), dtype=np.float32))
+    w.max_absent_frames_spin.setValue(2)
+    w.set_frame_data(np.zeros((10, 4, 4), dtype=np.float32))
+    assert w.max_absent_frames_spin.maximum() == 10
+    assert w.max_absent_frames_spin.value() == 2
+
+
+def test_max_absent_frames_resets_when_still_at_default(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.set_frame_data(np.zeros((5, 4, 4), dtype=np.float32))
+    assert w.max_absent_frames_spin.value() == 5
+    w.set_frame_data(np.zeros((8, 4, 4), dtype=np.float32))
+    assert w.max_absent_frames_spin.value() == 8
+
+
+def test_effective_mask_detect_both_falls_back_to_single_mask(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.detect_mode_combo.setCurrentIndex(2)  # Detect Both ROIs
+    m1 = np.zeros((4, 4), dtype=bool)
+    m1[1:3, 1:3] = True
+    w.set_roi_mask("roi_1", m1)
+    w.set_roi_mask("roi_2", None)
+    assert w._effective_mask() is m1
+
+
+def test_compute_roi_origin_none_when_no_locations(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    assert w._compute_roi_origin() is None
+
+
+def test_compute_roi_origin_single_roi2(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.neuron_locations = np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float64)
+    w.roi_masks["roi_1"] = None
+    w.roi_masks["roi_2"] = np.ones((5, 5), dtype=bool)
+    origin = w._compute_roi_origin()
+    assert origin is not None
+    assert np.all(origin == 1)
+
+
+def test_compute_roi_origin_two_masks_assignment(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    m1 = np.zeros((12, 12), dtype=bool)
+    m2 = np.zeros((12, 12), dtype=bool)
+    m1[0:4, 0:4] = True
+    m2[8:12, 8:12] = True
+    w.roi_masks["roi_1"] = m1
+    w.roi_masks["roi_2"] = m2
+    w.neuron_locations = np.array([[1.0, 1.0], [9.0, 9.0]], dtype=np.float64)
+    origin = w._compute_roi_origin()
+    assert origin.tolist() == [0, 1]
+
+
+def test_load_detection_data_with_mean_frame_and_callbacks(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    cb = MagicMock()
+    w.set_trajectory_plot_callback(cb)
+    locs = np.array([[1.0, 2.0]], dtype=np.float64)
+    traj = np.zeros((1, 3, 2), dtype=np.float64)
+    qual = np.array([True], dtype=bool)
+    mean = np.ones((8, 8), dtype=np.float32)
+    w.load_detection_data(
+        locs,
+        traj,
+        qual,
+        mean_frame=mean,
+        detection_params={"cell_size": 12, "max_absent_frames": 3},
+    )
+    assert w.mean_frame is mean
+    assert w.export_locations_btn.isEnabled()
+    cb.assert_called_once()
+    # No ROI masks: origin defaults to zeros (same length as locations).
+    assert np.array_equal(cb.call_args.kwargs["roi_origin"], np.zeros(1, dtype=np.intp))
+
+
+def test_load_detection_data_derives_frames_from_stack(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    stack = np.random.default_rng(1).random((4, 6, 6)).astype(np.float32)
+    w.set_frame_data(stack)
+    mask = np.zeros((6, 6), dtype=bool)
+    mask[2:5, 2:5] = True
+    w.set_roi_mask("roi_1", mask)
+    locs = np.array([[3.0, 3.0]], dtype=np.float64)
+    traj = np.zeros((1, 4, 2), dtype=np.float64)
+    qual = np.array([True], dtype=bool)
+    w.load_detection_data(locs, traj, qual, mean_frame=None, detection_params=None)
+    assert w.mean_frame is not None and w.mean_frame.shape == (6, 6)
+    assert w._display_frame is not None
+
+
+def test_load_detection_data_switches_to_both_when_saved_dual_roi(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    m1 = np.zeros((8, 8), dtype=bool)
+    m2 = np.zeros((8, 8), dtype=bool)
+    m1[0:4, 0:4] = True
+    m2[4:8, 4:8] = True
+    w.set_roi_mask("roi_1", m1)
+    w.set_roi_mask("roi_2", m2)
+    locs = np.array([[1.0, 1.0], [6.0, 6.0]], dtype=np.float64)
+    traj = np.zeros((2, 2, 2), dtype=np.float64)
+    qual = np.array([True, True], dtype=bool)
+    roi_origin = np.array([0, 1], dtype=np.intp)
+    w.load_detection_data(locs, traj, qual, mean_frame=np.ones((8, 8), dtype=np.float32), roi_origin=roi_origin)
+    assert w.detect_mode_combo.currentText() == "Detect Both ROIs"
+
+
+def test_load_detection_data_uses_saved_roi_origin_in_callback(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    cb = MagicMock()
+    w.set_trajectory_plot_callback(cb)
+    locs = np.array([[1.0, 1.0]], dtype=np.float64)
+    traj = np.zeros((1, 2, 2), dtype=np.float64)
+    qual = np.array([True], dtype=bool)
+    roi_origin = np.array([1], dtype=np.intp)
+    w.load_detection_data(locs, traj, qual, mean_frame=np.ones((4, 4), dtype=np.float32), roi_origin=roi_origin)
+    cb.assert_called_once()
+    assert np.array_equal(cb.call_args.kwargs["roi_origin"], roi_origin)
+
+
+def test_reset_detection_state_clears(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.neuron_locations = np.array([[0.0, 0.0]], dtype=np.float64)
+    w.export_locations_btn.setEnabled(True)
+    w.reset_detection_state()
+    assert w.neuron_locations is None
+    assert not w.export_locations_btn.isEnabled()
+
+
+def test_clear_results_resets_masks(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.set_roi_mask("roi_1", np.ones((3, 3), dtype=bool))
+    w.neuron_locations = np.array([[0.0, 0.0]], dtype=np.float64)
+    w.clear_results()
+    assert w.roi_masks["roi_1"] is None
+    assert w.neuron_locations is None
+
+
+def test_update_ui_state_no_stack_message(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    w.set_roi_mask("roi_1", np.ones((3, 3), dtype=bool))
+    w.set_image_processor(MagicMock())
+    w._update_ui_state()
+    assert "No image stack" in w.status_label.text()
+
+
+def test_run_detection_warns_when_not_ready(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    with patch.object(QMessageBox, "warning") as warn:
+        w._run_detection()
+    warn.assert_called_once()
+
+
+def test_export_locations_warns_when_empty(qapp: QApplication) -> None:
+    w = NeuronDetectionWidget()
+    with patch.object(QMessageBox, "warning") as warn:
+        w._export_locations()
+    warn.assert_called_once()
+
+
+def test_export_locations_writes_csv(qapp: QApplication, tmp_path) -> None:
+    w = NeuronDetectionWidget()
+    w.experiment = MagicMock()
+    w.experiment.name = "ExpA"
+    w.neuron_locations = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    w.quality_mask = np.array([True, False], dtype=bool)
+    target = tmp_path / "out.csv"
+    with (
+        patch("ui.neuron_detection_widget.QFileDialog.getSaveFileName", return_value=(str(target), "")),
+        patch.object(QMessageBox, "information"),
+    ):
+        w._export_locations()
+    text = target.read_text(encoding="utf-8")
+    assert "Y,X,Quality" in text.replace(" ", "")
+    assert "1,2,Good" in text
+
+
+def test_export_trajectories_writes_npy(qapp: QApplication, tmp_path) -> None:
+    w = NeuronDetectionWidget()
+    w.experiment = MagicMock()
+    w.experiment.name = "ExpA"
+    arr = np.arange(6, dtype=np.float64).reshape(2, 3)
+    w.neuron_trajectories = arr
+    target = tmp_path / "t.npy"
+    with (
+        patch("ui.neuron_detection_widget.QFileDialog.getSaveFileName", return_value=(str(target), "")),
+        patch.object(QMessageBox, "information"),
+    ):
+        w._export_trajectories()
+    assert np.array_equal(np.load(str(target)), arr)
+
+
+def test_export_all_writes_csv(qapp: QApplication, tmp_path) -> None:
+    w = NeuronDetectionWidget()
+    w.experiment = MagicMock()
+    w.experiment.name = "ExpA"
+    w.neuron_locations = np.array([[1.0, 2.0]], dtype=np.float64)
+    w.quality_mask = np.array([True], dtype=bool)
+    w.neuron_trajectories = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+    target = tmp_path / "all.csv"
+    with (
+        patch("ui.neuron_detection_widget.QFileDialog.getSaveFileName", return_value=(str(target), "")),
+        patch.object(QMessageBox, "information"),
+    ):
+        w._export_all()
+    lines = target.read_text(encoding="utf-8").strip().splitlines()
+    assert "Frame_0" in lines[0]
+    assert "1,2,Good" in lines[1]

--- a/tests/test_public_user_feature.py
+++ b/tests/test_public_user_feature.py
@@ -1,0 +1,872 @@
+"""Tests for the Public User feature: sync, permissions, visibility flag, and credits."""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QComboBox, QDialog, QMessageBox, QPushButton, QSpinBox, QToolButton, QWidget
+
+from core.experiment_manager import Experiment, ExperimentManager
+from core.roi import ROI
+from ui.main_window import MainWindow
+from ui.public_user_dialog import (
+    PUBLIC_USER_NAME,
+    ReadOnlyGuard,
+    ensure_public_user_exists,
+    is_public_user,
+    register_public_experiment,
+    sync_public_experiments,
+    unregister_public_experiment,
+)
+from ui.startup_dialog import RecentExperimentRow, StartupDialog, _public_recent_row_label
+from ui.user_selection_dialog import UserSelectionDialog, _list_existing_users, _UserCard
+from ui.workflow import WorkflowManager, WorkflowStepper
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _minimal_nexp(*, name: str = "Exp", is_public: bool = False) -> dict:
+    return {
+        "version": "1.0",
+        "experiment": {
+            "name": name,
+            "image_stack": {"path": "", "file_list": [], "count": 0},
+            "is_public": is_public,
+        },
+    }
+
+
+@pytest.fixture
+def fake_users_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect ``users/`` layout under tmp_path (must match ``_repo_root`` layout)."""
+    root = tmp_path / "repo_root"
+    root.mkdir()
+    (root / "users").mkdir()
+    monkeypatch.setattr("ui.public_user_dialog._repo_root", lambda: root)
+    return root
+
+
+# ── public_user_dialog helpers ─────────────────────────────────────────────
+
+
+def test_is_public_user_exact_string_only() -> None:
+    assert is_public_user(PUBLIC_USER_NAME) is True
+    assert is_public_user("public") is False
+    assert is_public_user("PUBLIC") is False
+    assert is_public_user("alice") is False
+
+
+def test_ensure_public_user_creates_directories(fake_users_root: Path) -> None:
+    exp_dir = ensure_public_user_exists()
+    assert exp_dir == fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+    assert exp_dir.is_dir()
+    recent = fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json"
+    assert recent.is_file()
+    assert json.loads(recent.read_text(encoding="utf-8")) == {"recent": []}
+
+
+def test_ensure_public_user_profile_appears_in_user_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """After ensure_public_user_exists(), the Public profile is listed like any user."""
+    root = tmp_path / "repo_root"
+    root.mkdir()
+    (root / "users").mkdir()
+    monkeypatch.setattr("ui.public_user_dialog._repo_root", lambda: root)
+    monkeypatch.setattr("ui.user_selection_dialog._repo_root", lambda: root)
+    assert _list_existing_users() == []
+    ensure_public_user_exists()
+    assert PUBLIC_USER_NAME in _list_existing_users()
+
+
+def test_on_delete_user_does_not_remove_public_profile(app, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Public User cannot be deleted (handler no-ops before confirm or rmtree)."""
+    removed: list[Path] = []
+    monkeypatch.setattr(
+        "ui.user_selection_dialog.shutil.rmtree",
+        lambda p, *args, **kwargs: removed.append(Path(p)),
+    )
+    dlg = UserSelectionDialog()
+    dlg._on_delete_user(PUBLIC_USER_NAME)
+    assert removed == []
+
+
+def test_sync_public_experiments_copies_only_nested_is_public(
+    fake_users_root: Path,
+) -> None:
+    alice_exp = fake_users_root / "users" / "alice" / "experiments"
+    alice_exp.mkdir(parents=True)
+    (alice_exp / "study.nexp").write_text(
+        json.dumps(_minimal_nexp(name="My Study", is_public=True)),
+        encoding="utf-8",
+    )
+    (alice_exp / "private.nexp").write_text(
+        json.dumps(_minimal_nexp(name="Secret", is_public=False)),
+        encoding="utf-8",
+    )
+    # Top-level is_public must not count (only experiment.is_public)
+    bad = _minimal_nexp(name="Bad", is_public=False)
+    bad["is_public"] = True
+    (alice_exp / "spoof.nexp").write_text(json.dumps(bad), encoding="utf-8")
+
+    sync_public_experiments()
+
+    pub_dir = fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+    assert (pub_dir / "alice__study.nexp").is_file()
+    assert not (pub_dir / "alice__private.nexp").exists()
+    assert not (pub_dir / "alice__spoof.nexp").exists()
+
+    recent = json.loads(
+        (fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json").read_text(encoding="utf-8")
+    )
+    assert len(recent["recent"]) == 1
+    entry = recent["recent"][0]
+    assert entry["name"] == "My Study"
+    assert entry["owner"] == "alice"
+    assert entry["path"].endswith("alice__study.nexp")
+
+
+def test_sync_public_experiments_owner_preserves_mixed_case_folder_name(
+    fake_users_root: Path,
+) -> None:
+    udir = fake_users_root / "users" / "MiXeDCase" / "experiments"
+    udir.mkdir(parents=True)
+    (udir / "e.nexp").write_text(json.dumps(_minimal_nexp(name="E", is_public=True)), encoding="utf-8")
+    sync_public_experiments()
+    recent = json.loads(
+        (fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json").read_text(encoding="utf-8")
+    )
+    assert recent["recent"][0]["owner"] == "MiXeDCase"
+    label = _public_recent_row_label(recent["recent"][0], recent["recent"][0]["path"])
+    assert label == "E - by MiXeDCase"
+
+
+def test_sync_public_experiments_removes_stale_copy_when_made_private(
+    fake_users_root: Path,
+) -> None:
+    alice_exp = fake_users_root / "users" / "alice" / "experiments"
+    alice_exp.mkdir(parents=True)
+    path = alice_exp / "gone.nexp"
+    path.write_text(json.dumps(_minimal_nexp(name="Gone", is_public=True)), encoding="utf-8")
+    sync_public_experiments()
+    pub_copy = fake_users_root / "users" / PUBLIC_USER_NAME / "experiments" / "alice__gone.nexp"
+    assert pub_copy.is_file()
+
+    path.write_text(json.dumps(_minimal_nexp(name="Gone", is_public=False)), encoding="utf-8")
+    sync_public_experiments()
+    assert not pub_copy.exists()
+    recent = json.loads(
+        (fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json").read_text(encoding="utf-8")
+    )
+    assert recent["recent"] == []
+
+
+def test_user_selection_card_hides_delete_for_public_profile(app) -> None:
+    parent = QWidget()
+    card = _UserCard(PUBLIC_USER_NAME, grid_row=0, grid_col=0, grid_cols=1, parent=parent)
+    parent.show()
+    card.show()
+    app.processEvents()
+    del_btns = card.findChildren(QToolButton)
+    assert len(del_btns) == 1
+    assert del_btns[0].isVisible() is False
+
+
+def test_user_selection_card_shows_delete_for_normal_profile(app) -> None:
+    parent = QWidget()
+    card = _UserCard("alice", grid_row=0, grid_col=0, grid_cols=1, parent=parent)
+    parent.show()
+    card.show()
+    app.processEvents()
+    del_btns = card.findChildren(QToolButton)
+    assert len(del_btns) == 1
+    assert del_btns[0].isVisible() is True
+
+
+def test_read_only_guard_reverts_enable(app) -> None:
+    w = QPushButton("x")
+    w.setEnabled(True)
+    g = ReadOnlyGuard.lock(w)
+    assert w.isEnabled() is False
+    w.setEnabled(True)
+    app.processEvents()
+    assert w.isEnabled() is False
+    w.removeEventFilter(g)
+
+
+def test_read_only_guard_event_filter_no_reentrant_disable_when_already_off(app) -> None:
+    w = QPushButton("x")
+    g = ReadOnlyGuard(w)
+    w.installEventFilter(g)
+    w.setEnabled(False)
+    assert g.eventFilter(w, QEvent(QEvent.Type.EnabledChange)) is False
+
+
+def test_ensure_public_user_skips_recent_write_when_file_already_exists(fake_users_root: Path) -> None:
+    ensure_public_user_exists()
+    recent = fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json"
+    before = recent.read_text(encoding="utf-8")
+    ensure_public_user_exists()
+    assert recent.read_text(encoding="utf-8") == before
+
+
+def test_sync_public_experiments_returns_when_users_path_not_a_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "repo_root"
+    root.mkdir()
+    (root / "users").write_text("not-a-directory", encoding="utf-8")
+    monkeypatch.setattr("ui.public_user_dialog._repo_root", lambda: root)
+    sync_public_experiments()
+    assert not (root / "users" / PUBLIC_USER_NAME / "experiments").exists()
+
+
+def test_sync_public_experiments_skips_invalid_json_and_non_dict_experiment(
+    fake_users_root: Path,
+) -> None:
+    alice = fake_users_root / "users" / "alice" / "experiments"
+    alice.mkdir(parents=True)
+    (alice / "bad.nexp").write_text("not json {", encoding="utf-8")
+    (alice / "weird.nexp").write_text(
+        json.dumps({"version": "1.0", "experiment": "not-a-dict"}),
+        encoding="utf-8",
+    )
+    (alice / "good.nexp").write_text(json.dumps(_minimal_nexp(name="Ok", is_public=True)), encoding="utf-8")
+    sync_public_experiments()
+    pub = fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+    assert (pub / "alice__good.nexp").is_file()
+    assert len(list(pub.glob("*.nexp"))) == 1
+
+
+def test_sync_public_experiments_skips_copy_oserror(fake_users_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    alice = fake_users_root / "users" / "alice" / "experiments"
+    alice.mkdir(parents=True)
+    (alice / "p.nexp").write_text(json.dumps(_minimal_nexp(is_public=True)), encoding="utf-8")
+    monkeypatch.setattr("ui.public_user_dialog.shutil.copy2", Mock(side_effect=OSError("denied")))
+    sync_public_experiments()
+    pub = fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+    assert not any(pub.iterdir())
+
+
+def test_sync_public_experiments_skips_subdir_without_experiments_folder(fake_users_root: Path) -> None:
+    (fake_users_root / "users" / "bob").mkdir()
+    sync_public_experiments()
+    recent = json.loads(
+        (fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json").read_text(encoding="utf-8")
+    )
+    assert recent["recent"] == []
+
+
+def test_register_public_experiment_prepends_and_deduplicates(fake_users_root: Path) -> None:
+    ensure_public_user_exists()
+    recent = fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json"
+    p1 = fake_users_root / "a.nexp"
+    p1.write_text("{}", encoding="utf-8")
+    register_public_experiment(str(p1), "Alpha")
+    register_public_experiment(str(p1), "Alpha again")
+    data = json.loads(recent.read_text(encoding="utf-8"))
+    assert len(data["recent"]) == 1
+    assert data["recent"][0]["name"] == "Alpha again"
+
+
+def test_register_public_experiment_corrupt_read_falls_back(fake_users_root: Path) -> None:
+    ensure_public_user_exists()
+    recent = fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json"
+    recent.write_text("not json", encoding="utf-8")
+    p = fake_users_root / "z.nexp"
+    p.write_text("{}", encoding="utf-8")
+    register_public_experiment(str(p), "Zed")
+    data = json.loads(recent.read_text(encoding="utf-8"))
+    assert len(data["recent"]) == 1
+
+
+def test_unregister_public_experiment_noop_when_missing_recent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "r"
+    root.mkdir()
+    monkeypatch.setattr("ui.public_user_dialog._repo_root", lambda: root)
+    unregister_public_experiment("/no/such/path.nexp")
+
+
+def test_unregister_public_experiment_removes_path(fake_users_root: Path) -> None:
+    ensure_public_user_exists()
+    p = fake_users_root / "x.nexp"
+    p.write_text("{}", encoding="utf-8")
+    register_public_experiment(str(p))
+    unregister_public_experiment(str(p))
+    data = json.loads(
+        (fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json").read_text(encoding="utf-8")
+    )
+    assert data["recent"] == []
+
+
+def test_repo_root_is_repository_containing_src_layout() -> None:
+    """Exercise real ``_repo_root()`` (not redirected by tests)."""
+    import ui.public_user_dialog as pud
+
+    root = pud._repo_root()
+    assert (root / "src" / "ui" / "public_user_dialog.py").is_file()
+
+
+def test_ensure_public_user_exists_swallows_oserror_on_mkdir(
+    fake_users_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "mkdir", Mock(side_effect=OSError("denied")))
+    # Must not raise; returns path under fake root even when mkdir fails.
+    out = ensure_public_user_exists()
+    assert out == fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+
+
+def _patch_open_fail_recent_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_open = builtins.open
+
+    def _open(file, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if mode == "w" and "recent_experiments.json" in str(file):
+            raise OSError("write denied")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _open)
+
+
+def test_sync_public_experiments_swallows_oserror_on_recent_rewrite(
+    fake_users_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alice = fake_users_root / "users" / "alice" / "experiments"
+    alice.mkdir(parents=True)
+    (alice / "p.nexp").write_text(json.dumps(_minimal_nexp(is_public=True)), encoding="utf-8")
+    _patch_open_fail_recent_write(monkeypatch)
+    sync_public_experiments()
+
+
+def test_sync_public_experiments_swallows_oserror_on_stale_unlink(
+    fake_users_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alice = fake_users_root / "users" / "alice" / "experiments"
+    alice.mkdir(parents=True)
+    nexp = alice / "gone.nexp"
+    nexp.write_text(json.dumps(_minimal_nexp(is_public=True)), encoding="utf-8")
+    sync_public_experiments()
+    pub = fake_users_root / "users" / PUBLIC_USER_NAME / "experiments"
+    copy_path = pub / "alice__gone.nexp"
+    assert copy_path.is_file()
+    nexp.write_text(json.dumps(_minimal_nexp(is_public=False)), encoding="utf-8")
+    orig_unlink = Path.unlink
+
+    def _bad_unlink(self: Path, *a: object, **kw: object) -> None:
+        if self == copy_path:
+            raise OSError("in use")
+        return orig_unlink(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "unlink", _bad_unlink)
+    sync_public_experiments()
+
+
+def test_register_public_experiment_swallows_oserror_on_write(
+    fake_users_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ensure_public_user_exists()
+    p = fake_users_root / "w.nexp"
+    p.write_text("{}", encoding="utf-8")
+    _patch_open_fail_recent_write(monkeypatch)
+    register_public_experiment(str(p), "W")
+
+
+def test_unregister_public_experiment_corrupt_read_then_write_ok(fake_users_root: Path) -> None:
+    ensure_public_user_exists()
+    recent = fake_users_root / "users" / PUBLIC_USER_NAME / "recent_experiments.json"
+    recent.write_text("{not json", encoding="utf-8")
+    p = fake_users_root / "u.nexp"
+    p.write_text("{}", encoding="utf-8")
+    unregister_public_experiment(str(p))
+    data = json.loads(recent.read_text(encoding="utf-8"))
+    assert data["recent"] == []
+
+
+def test_unregister_public_experiment_swallows_oserror_on_write(
+    fake_users_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ensure_public_user_exists()
+    p = fake_users_root / "y.nexp"
+    p.write_text("{}", encoding="utf-8")
+    register_public_experiment(str(p))
+    _patch_open_fail_recent_write(monkeypatch)
+    unregister_public_experiment(str(p))
+
+
+# ── ExperimentManager: no writes into Public copies tree ───────────────────
+
+
+@pytest.fixture
+def recent_file_global(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "recent_experiments.json"
+    monkeypatch.setattr("core.experiment_manager.RECENT_FILE", path)
+    return path
+
+
+def test_save_experiment_rejected_under_public_experiments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, recent_file_global: Path
+) -> None:
+    monkeypatch.setattr("core.experiment_manager._repo_root", lambda: tmp_path)
+    pub = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    pub.mkdir(parents=True)
+    target = pub / "alice__x.nexp"
+    mgr = ExperimentManager(recent_file_global)
+    assert mgr.save_experiment(Experiment(name="N"), str(target)) is False
+    assert not target.exists()
+
+
+# ── StartupDialog: Public mode disables create/load ───────────────────────
+
+
+def test_startup_dialog_public_recent_list_shows_credit_line(app, tmp_path: Path) -> None:
+    user_root = tmp_path / "users" / PUBLIC_USER_NAME
+    exp_dir = user_root / "experiments"
+    exp_dir.mkdir(parents=True)
+    nexp = exp_dir / "alice__mine.nexp"
+    nexp.write_text(json.dumps(_minimal_nexp(name="Mine", is_public=False)), encoding="utf-8")
+    recent_path = user_root / "recent_experiments.json"
+    recent_path.write_text(
+        json.dumps(
+            {
+                "recent": [
+                    {
+                        "path": str(nexp.resolve()),
+                        "name": "Mine",
+                        "owner": "alice",
+                        "last_opened": "2026-01-01T00:00:00+00:00",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    dlg = StartupDialog(exp_dir)
+    rows = dlg.findChildren(RecentExperimentRow)
+    assert len(rows) == 1
+    assert rows[0].name_label.text() == "Mine - by alice"
+
+
+def test_startup_dialog_public_user_disables_new_and_load(app, tmp_path: Path) -> None:
+    exp_dir = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    exp_dir.mkdir(parents=True)
+    dlg = StartupDialog(exp_dir)
+    texts = [b.text() for b in dlg.findChildren(QPushButton)]
+    assert "Start New Experiment" in texts
+    new_btn = next(b for b in dlg.findChildren(QPushButton) if b.text() == "Start New Experiment")
+    load_btn = next(b for b in dlg.findChildren(QPushButton) if b.text() == "Load Existing Experiment")
+    assert new_btn.isEnabled() is False
+    assert load_btn.isEnabled() is False
+
+
+def test_startup_dialog_public_user_start_new_shows_message_only(app, tmp_path: Path) -> None:
+    exp_dir = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    exp_dir.mkdir(parents=True)
+    dlg = StartupDialog(exp_dir)
+    with patch.object(QMessageBox, "information", return_value=None) as inf:
+        dlg._start_new()
+    inf.assert_called_once()
+    with patch.object(QMessageBox, "information", return_value=None) as inf2:
+        dlg._load_existing()
+    inf2.assert_called_once()
+
+
+def test_startup_dialog_public_user_mouse_clicks_do_not_start_new_or_load(app, tmp_path: Path) -> None:
+    """Disabled New/Load buttons must not emit ``clicked`` (no dialog / file picker)."""
+    exp_dir = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    exp_dir.mkdir(parents=True)
+    dlg = StartupDialog(exp_dir)
+    new_btn = next(b for b in dlg.findChildren(QPushButton) if b.text() == "Start New Experiment")
+    load_btn = next(b for b in dlg.findChildren(QPushButton) if b.text() == "Load Existing Experiment")
+    with (
+        patch("ui.startup_dialog.NewExperimentDialog") as mock_new_cls,
+        patch(
+            "ui.startup_dialog.QFileDialog.getOpenFileName",
+            return_value=("/fake.nexp", "Neurolight Experiment (*.nexp)"),
+        ) as mock_open,
+    ):
+        QTest.mouseClick(new_btn, Qt.MouseButton.LeftButton)
+        QTest.mouseClick(load_btn, Qt.MouseButton.LeftButton)
+        app.processEvents()
+    mock_new_cls.assert_not_called()
+    mock_open.assert_not_called()
+
+
+# ── WorkflowStepper read-only toggling ─────────────────────────────────────
+
+
+def test_workflow_stepper_read_only_unlock_restores_buttons(app) -> None:
+    exp = Experiment(name="T")
+    wm = WorkflowManager(exp)
+    stepper = WorkflowStepper(wm)
+    first = next(iter(stepper._step_buttons.values()))
+    was = first.isEnabled()
+    stepper.set_read_only(True)
+    assert first.isEnabled() is False
+    stepper.set_read_only(False)
+    assert first.isEnabled() == was
+
+
+def test_workflow_stepper_read_only_mouse_click_does_not_emit_clicked(app) -> None:
+    exp = Experiment(name="T")
+    wm = WorkflowManager(exp)
+    stepper = WorkflowStepper(wm)
+    first = next(iter(stepper._step_buttons.values()))
+    slot = Mock()
+    first.clicked.connect(slot)
+    stepper.set_read_only(True)
+    QTest.mouseClick(first, Qt.MouseButton.LeftButton)
+    app.processEvents()
+    slot.assert_not_called()
+
+
+# ── MainWindow: public mode permissions and switching ─────────────────────
+
+
+class _DetStub:
+    def __init__(self) -> None:
+        self.detect_mode_combo = QComboBox()
+        self.cell_size_spin = QSpinBox()
+        self.num_peaks_spin = QSpinBox()
+        self.correlation_threshold_spin = QSpinBox()
+        self.max_absent_frames_spin = QSpinBox()
+        self.threshold_rel_spin = QSpinBox()
+        self.max_projection_checkbox = QWidget()
+        self.preprocess_sigma_spin = QSpinBox()
+        self.detrending_checkbox = QWidget()
+        self.detect_btn = QPushButton()
+
+
+class _LombStub:
+    def __init__(self) -> None:
+        self.sampling_interval_spin = QSpinBox()
+
+
+class _RayleighStub:
+    def __init__(self) -> None:
+        self.start_time_edit = QWidget()
+        self.interval_spin = QSpinBox()
+        self.interval_unit_combo = QComboBox()
+        self.plot_btn = QPushButton()
+
+
+@pytest.fixture
+def patched_main_window(app, tmp_path: Path):
+    sample_experiment = Experiment(name="Test Experiment", description="")
+    user_experiments_dir = tmp_path / "users" / "alice" / "experiments"
+    user_experiments_dir.mkdir(parents=True)
+
+    mock_viewer = QWidget()
+    mock_viewer.upload_btn = QPushButton()
+    for attr in (
+        "display_controls_panel",
+        "cull_controls_panel",
+    ):
+        setattr(mock_viewer, attr, QWidget())
+    mock_viewer.index = 0
+    mock_viewer.cache = Mock()
+    mock_viewer.current_roi = None
+    mock_viewer.image_label = Mock()
+    mock_viewer.filename_label = Mock()
+    mock_viewer.slider = Mock()
+    mock_viewer.set_stack = Mock()
+    mock_viewer.set_roi = Mock()
+    mock_viewer.reset = Mock()
+    mock_viewer.image_processor = Mock()
+    mock_viewer.get_current_roi = Mock(return_value=None)
+    mock_viewer.get_exposure = Mock(return_value=0)
+    mock_viewer.get_contrast = Mock(return_value=0)
+    mock_viewer.stackLoaded = Mock()
+    mock_viewer.stackLoaded.connect = Mock()
+    mock_viewer.roiSelected = Mock()
+    mock_viewer.roiSelected.connect = Mock()
+    mock_viewer.roiDeleted = Mock()
+    mock_viewer.roiDeleted.connect = Mock()
+    mock_viewer.displaySettingsChanged = Mock()
+    mock_viewer.displaySettingsChanged.connect = Mock()
+    mock_viewer.frameCullingChanged = Mock()
+    mock_viewer.frameCullingChanged.connect = Mock()
+    mock_viewer.set_filter_excluded = Mock()
+
+    det = _DetStub()
+    lomb = _LombStub()
+    ray = _RayleighStub()
+
+    mock_analysis = QWidget()
+    mock_analysis.roi_plot_widget = Mock()
+    mock_analysis.get_roi_plot_widget = Mock(return_value=mock_analysis.roi_plot_widget)
+    mock_analysis.get_neuron_detection_widget = Mock(return_value=det)
+    mock_analysis.get_neuron_trajectory_plot_widget = Mock(return_value=Mock())
+    mock_analysis.get_lomb_scargle_widget = Mock(return_value=lomb)
+    mock_analysis.get_rayleigh_plot_widget = Mock(return_value=ray)
+
+    mock_stack_handler = Mock()
+    mock_stack_handler.files = []
+    mock_stack_handler.associate_with_experiment = Mock()
+    mock_data_analyzer = Mock()
+
+    with (
+        patch("ui.main_window.ImageViewer", return_value=mock_viewer),
+        patch("ui.main_window.AnalysisPanel", return_value=mock_analysis),
+        patch("ui.main_window.ImageStackHandler", return_value=mock_stack_handler),
+        patch("ui.main_window.DataAnalyzer", return_value=mock_data_analyzer),
+        patch("ui.main_window.QTimer.singleShot"),
+    ):
+        window = MainWindow(sample_experiment, user_experiments_dir=user_experiments_dir)
+        window._det_stub = det  # type: ignore[attr-defined]
+        window._lomb_stub = lomb  # type: ignore[attr-defined]
+        yield window
+
+
+@pytest.fixture
+def patched_main_window_public(app, tmp_path: Path):
+    sample_experiment = Experiment(name="Pub Exp", description="")
+    public_exp_dir = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    public_exp_dir.mkdir(parents=True)
+
+    mock_viewer = QWidget()
+    mock_viewer.upload_btn = QPushButton()
+    mock_viewer.display_controls_panel = QWidget()
+    mock_viewer.cull_controls_panel = QWidget()
+    mock_viewer.index = 0
+    mock_viewer.cache = Mock()
+    mock_viewer.current_roi = None
+    mock_viewer.image_label = Mock()
+    mock_viewer.filename_label = Mock()
+    mock_viewer.slider = Mock()
+    mock_viewer.set_stack = Mock()
+    mock_viewer.set_roi = Mock()
+    mock_viewer.reset = Mock()
+    mock_viewer.image_processor = Mock()
+    mock_viewer.get_current_roi = Mock(return_value=None)
+    mock_viewer.get_exposure = Mock(return_value=0)
+    mock_viewer.get_contrast = Mock(return_value=0)
+    mock_viewer.stackLoaded = Mock()
+    mock_viewer.stackLoaded.connect = Mock()
+    mock_viewer.roiSelected = Mock()
+    mock_viewer.roiSelected.connect = Mock()
+    mock_viewer.roiDeleted = Mock()
+    mock_viewer.roiDeleted.connect = Mock()
+    mock_viewer.displaySettingsChanged = Mock()
+    mock_viewer.displaySettingsChanged.connect = Mock()
+    mock_viewer.frameCullingChanged = Mock()
+    mock_viewer.frameCullingChanged.connect = Mock()
+    mock_viewer.set_filter_excluded = Mock()
+
+    det = _DetStub()
+    lomb = _LombStub()
+    ray = _RayleighStub()
+
+    mock_analysis = QWidget()
+    mock_analysis.roi_plot_widget = Mock()
+    mock_analysis.get_roi_plot_widget = Mock(return_value=mock_analysis.roi_plot_widget)
+    mock_analysis.get_neuron_detection_widget = Mock(return_value=det)
+    mock_analysis.get_neuron_trajectory_plot_widget = Mock(return_value=Mock())
+    mock_analysis.get_lomb_scargle_widget = Mock(return_value=lomb)
+    mock_analysis.get_rayleigh_plot_widget = Mock(return_value=ray)
+
+    mock_stack_handler = Mock()
+    mock_stack_handler.files = []
+    mock_stack_handler.associate_with_experiment = Mock()
+    mock_data_analyzer = Mock()
+
+    with (
+        patch("ui.main_window.ImageViewer", return_value=mock_viewer),
+        patch("ui.main_window.AnalysisPanel", return_value=mock_analysis),
+        patch("ui.main_window.ImageStackHandler", return_value=mock_stack_handler),
+        patch("ui.main_window.DataAnalyzer", return_value=mock_data_analyzer),
+        patch("ui.main_window.QTimer.singleShot"),
+    ):
+        window = MainWindow(sample_experiment, user_experiments_dir=public_exp_dir)
+        window._det_stub = det  # type: ignore[attr-defined]
+        window._lomb_stub = lomb  # type: ignore[attr-defined]
+        yield window
+
+
+def test_main_window_public_user_disables_save_and_locks_detection(
+    patched_main_window_public,
+) -> None:
+    mw = patched_main_window_public
+    assert mw._is_public_user_mode() is True
+    assert mw._action_save is not None
+    assert mw._action_save.isEnabled() is False
+    det: _DetStub = mw._det_stub  # type: ignore[assignment]
+    assert det.detect_btn.isEnabled() is False
+    assert mw._lomb_stub.sampling_interval_spin.isEnabled() is False  # type: ignore[attr-defined]
+
+
+def test_main_window_public_user_clicks_do_not_trigger_save_or_detection(patched_main_window_public, app) -> None:
+    """Disabled Save action and Detect button must not emit when activated or clicked."""
+    mw = patched_main_window_public
+    save_slot = Mock()
+    mw._action_save.triggered.connect(save_slot)
+    mw._action_save.trigger()
+    app.processEvents()
+    save_slot.assert_not_called()
+
+    det: _DetStub = mw._det_stub  # type: ignore[assignment]
+    det_slot = Mock()
+    det.detect_btn.clicked.connect(det_slot)
+    QTest.mouseClick(det.detect_btn, Qt.MouseButton.LeftButton)
+    app.processEvents()
+    det_slot.assert_not_called()
+
+
+def test_main_window_switch_from_public_to_normal_restores_save(patched_main_window_public, tmp_path: Path) -> None:
+    mw = patched_main_window_public
+    assert mw._action_save.isEnabled() is False
+    lomb_before: _LombStub = mw._lomb_stub  # type: ignore[assignment]
+    assert lomb_before.sampling_interval_spin.isEnabled() is False
+    normal = tmp_path / "users" / "alice" / "experiments"
+    normal.mkdir(parents=True)
+    mw.user_experiments_dir = normal
+    mw._sync_public_user_mode()
+    assert mw._is_public_user_mode() is False
+    assert mw._action_save.isEnabled() is True
+    lomb_after: _LombStub = mw._lomb_stub  # type: ignore[assignment]
+    assert lomb_after.sampling_interval_spin.isEnabled() is True
+
+
+def test_main_window_switch_from_normal_to_public_applies_restrictions(patched_main_window, tmp_path: Path) -> None:
+    mw = patched_main_window
+    assert mw._is_public_user_mode() is False
+    assert mw._action_save.isEnabled() is True
+    pub = tmp_path / "users" / PUBLIC_USER_NAME / "experiments"
+    pub.mkdir(parents=True)
+    mw.user_experiments_dir = pub
+    mw._sync_public_user_mode()
+    assert mw._is_public_user_mode() is True
+    assert mw._action_save.isEnabled() is False
+
+
+def test_main_window_no_visibility_button_for_public_user(patched_main_window_public) -> None:
+    assert patched_main_window_public._visibility_btn is None
+
+
+def test_main_window_public_update_visibility_button_noops_without_widget(
+    patched_main_window_public,
+) -> None:
+    patched_main_window_public._update_visibility_button()
+
+
+def test_main_window_apply_public_restrictions_noop_when_not_public(patched_main_window) -> None:
+    mw = patched_main_window
+    mw._public_user_guards.clear()
+    mw._apply_public_user_restrictions()
+    assert mw._public_user_guards == []
+
+
+def test_main_window_is_public_false_when_user_dir_unset(patched_main_window) -> None:
+    mw = patched_main_window
+    mw.user_experiments_dir = None
+    assert mw._is_public_user_mode() is False
+
+
+def test_main_window_public_save_save_as_stack_settings_crop_align_show_readonly(
+    patched_main_window_public, app
+) -> None:
+    mw = patched_main_window_public
+    with patch.object(QMessageBox, "information", return_value=None) as inf:
+        mw._save()
+        mw._save_as()
+        mw._open_image_stack()
+        mw._open_experiment_settings()
+        mw._crop_stack_to_roi()
+        mw._align_images()
+    assert inf.call_count == 6
+
+
+def test_main_window_public_autosave_and_save_roi_are_noops(patched_main_window_public) -> None:
+    mw = patched_main_window_public
+    mw.current_experiment_path = "/tmp/fake.nexp"
+    with patch.object(mw.manager, "save_experiment", new=Mock()) as save:
+        mw.autosave_experiment()
+        save.assert_not_called()
+    with patch.object(mw.manager, "save_experiment", new=Mock()) as save2:
+        mw._save_roi_to_experiment("roi_1", ROI(x=0, y=0, width=2, height=2))
+        save2.assert_not_called()
+
+
+def test_main_window_public_close_event_does_not_save(patched_main_window_public, app, tmp_path: Path) -> None:
+    mw = patched_main_window_public
+    mw.current_experiment_path = str(tmp_path / "x.nexp")
+    with patch.object(mw.manager, "save_experiment", new=Mock()) as save:
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.Yes):
+            ev = QCloseEvent()
+            mw.closeEvent(ev)
+    save.assert_not_called()
+    assert ev.isAccepted()
+
+
+def test_main_window_public_close_experiment_calls_sync(
+    patched_main_window_public, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mw = patched_main_window_public
+    calls: list[int] = []
+    monkeypatch.setattr("ui.public_user_dialog.sync_public_experiments", lambda: calls.append(1))
+
+    class _StubStartup:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        def exec(self) -> int:
+            return QDialog.Rejected
+
+    with patch.object(QMessageBox, "question", return_value=QMessageBox.Yes):
+        with patch("ui.main_window.StartupDialog", _StubStartup):
+            with patch("ui.main_window.QApplication.quit", new=Mock()):
+                mw._close_experiment()
+    assert calls == [1]
+
+
+def test_main_window_visibility_button_for_normal_user(patched_main_window) -> None:
+    assert patched_main_window._visibility_btn is not None
+
+
+def test_toggle_experiment_visibility_public_sets_flag_and_saves(
+    patched_main_window, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_users_root: Path
+) -> None:
+    """Using fake repo root so sync_public_experiments does not touch the real project."""
+    monkeypatch.setattr("ui.public_user_dialog._repo_root", lambda: fake_users_root)
+    mw = patched_main_window
+    mw.experiment.is_public = False
+    nexp = tmp_path / "alice_exp.nexp"
+    nexp.write_text(json.dumps(_minimal_nexp(name="Test Experiment", is_public=False)), encoding="utf-8")
+    mw.current_experiment_path = str(nexp)
+    sync_calls: list[int] = []
+
+    def _track_sync() -> None:
+        sync_calls.append(1)
+
+    monkeypatch.setattr("ui.public_user_dialog.sync_public_experiments", _track_sync)
+
+    with patch.object(mw.manager, "save_experiment", return_value=True) as mock_save:
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.Yes):
+            mw._toggle_experiment_visibility()
+    assert mw.experiment.is_public is True
+    mock_save.assert_called_once()
+    assert sync_calls == [1]
+
+    with patch.object(mw.manager, "save_experiment", return_value=True) as mock_save2:
+        mw._toggle_experiment_visibility()
+    assert mw.experiment.is_public is False
+    assert mock_save2.called
+
+
+def test_experiment_is_public_round_trips_json() -> None:
+    exp = Experiment(name="X", is_public=True)
+    blob = json.loads(json.dumps(exp.to_json()))
+    restored = Experiment.from_json(blob)
+    assert restored.is_public is True
+    exp2 = Experiment(name="Y", is_public=False)
+    blob2 = json.loads(json.dumps(exp2.to_json()))
+    assert Experiment.from_json(blob2).is_public is False

--- a/tests/test_public_user_feature.py
+++ b/tests/test_public_user_feature.py
@@ -61,10 +61,11 @@ def fake_users_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 # ── public_user_dialog helpers ─────────────────────────────────────────────
 
 
-def test_is_public_user_exact_string_only() -> None:
+def test_is_public_user_tolerates_casing_and_whitespace() -> None:
     assert is_public_user(PUBLIC_USER_NAME) is True
-    assert is_public_user("public") is False
-    assert is_public_user("PUBLIC") is False
+    assert is_public_user("public") is True
+    assert is_public_user("PUBLIC") is True
+    assert is_public_user(" Public ") is True
     assert is_public_user("alice") is False
 
 

--- a/tests/test_roi_selection_dialog.py
+++ b/tests/test_roi_selection_dialog.py
@@ -1,0 +1,309 @@
+"""Tests for ROISelectionDialog and _ROIGraphicsView (zoom, polygon flow, overlays)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from PySide6.QtCore import QPoint, QPointF, Qt
+from PySide6.QtGui import QKeyEvent, QWheelEvent
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QDialog
+
+from core.roi import ROI, ROIHandle, ROIShape
+from ui.roi_selection_dialog import ROISelectionDialog
+
+
+def _mb_event(button: Qt.MouseButton) -> SimpleNamespace:
+    return SimpleNamespace(button=lambda b=button: b)
+
+
+def _empty_event() -> SimpleNamespace:
+    return SimpleNamespace()
+
+
+@pytest.fixture
+def app():
+    if not QApplication.instance():
+        return QApplication([])
+    return QApplication.instance()
+
+
+def _wheel_event(view, *, angle_y: int = 120) -> QWheelEvent:
+    pos = QPointF(view.width() / 2, view.height() / 2)
+    return QWheelEvent(
+        pos,
+        pos,
+        QPoint(0, 0),
+        QPoint(0, angle_y),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+
+
+def test_roi_dialog_opens_grayscale_and_rgb(app) -> None:
+    gray = np.zeros((40, 50), dtype=np.uint8)
+    dlg = ROISelectionDialog(gray)
+    dlg._on_fit_view()
+    assert "ROI Selection" in dlg.windowTitle()
+    dlg.close()
+
+    rgb = np.zeros((20, 20, 3), dtype=np.uint8)
+    dlg2 = ROISelectionDialog(rgb, active_roi_label="ROI 2")
+    dlg2._on_fit_view()
+    assert "ROI 2" in dlg2.windowTitle()
+    dlg2.close()
+
+
+def test_roi_dialog_other_roi_polygon_overlay(app) -> None:
+    img = np.zeros((60, 60), dtype=np.uint8)
+    other = ROI(
+        x=0,
+        y=0,
+        width=60,
+        height=60,
+        shape=ROIShape.POLYGON,
+        points=[(5, 5), (55, 5), (55, 55), (5, 55)],
+    )
+    dlg = ROISelectionDialog(img, other_roi=other)
+    dlg._on_fit_view()
+    dlg._update_overlay()
+    dlg.close()
+
+
+def test_roi_dialog_zoom_toolbar_and_view_wheel(app) -> None:
+    img = np.zeros((80, 80), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    QTest.mouseClick(dlg._zoom_in_btn, Qt.MouseButton.LeftButton)
+    QTest.mouseClick(dlg._zoom_out_btn, Qt.MouseButton.LeftButton)
+    QTest.mouseClick(dlg._fit_btn, Qt.MouseButton.LeftButton)
+    dlg._view.wheelEvent(_wheel_event(dlg._view, angle_y=120))
+    dlg._view.wheelEvent(_wheel_event(dlg._view, angle_y=-120))
+    dlg._view.wheelEvent(_wheel_event(dlg._view, angle_y=0))
+    dlg.close()
+
+
+def test_roi_dialog_polygon_draw_complete_accept(app) -> None:
+    img = np.zeros((100, 100), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    for xy in ((10.0, 10.0), (80.0, 10.0), (80.0, 80.0)):
+        dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(*xy))
+    dlg._complete_polygon()
+    assert dlg._current_roi is not None
+    assert dlg._current_roi.shape == ROIShape.POLYGON
+    QTest.mouseClick(dlg._accept_btn, Qt.MouseButton.LeftButton)
+    assert dlg.result() == QDialog.DialogCode.Accepted
+    dlg.close()
+
+
+def test_roi_dialog_toggle_adjust_updates_ui(app) -> None:
+    pts = [(5, 5), (90, 5), (90, 90), (5, 90)]
+    roi = ROI.from_dict({"shape": "polygon", "points": pts})
+    img = np.zeros((100, 100), dtype=np.uint8)
+    dlg = ROISelectionDialog(img, existing_roi=roi)
+    dlg._on_fit_view()
+    QTest.mouseClick(dlg._adjust_btn, Qt.MouseButton.LeftButton)
+    assert dlg._adjust_mode is True
+    QTest.mouseClick(dlg._adjust_btn, Qt.MouseButton.LeftButton)
+    assert dlg._adjust_mode is False
+    dlg.close()
+
+
+def test_roi_dialog_right_click_undo_point_while_drawing(app) -> None:
+    img = np.zeros((50, 50), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(5, 5))
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.RightButton), QPointF(40, 40))
+    assert dlg._polygon_points == []
+    dlg.close()
+
+
+def test_roi_dialog_key_plus_minus_zoom_escape(app) -> None:
+    img = np.zeros((40, 40), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._handle_key_press(QKeyEvent(QKeyEvent.Type.KeyPress, int(Qt.Key.Key_Plus), Qt.KeyboardModifier.NoModifier))
+    dlg._handle_key_press(QKeyEvent(QKeyEvent.Type.KeyPress, int(Qt.Key.Key_Minus), Qt.KeyboardModifier.NoModifier))
+    dlg._handle_key_press(QKeyEvent(QKeyEvent.Type.KeyPress, int(Qt.Key.Key_Escape), Qt.KeyboardModifier.NoModifier))
+    assert dlg.result() == QDialog.DialogCode.Rejected
+    dlg.close()
+
+
+def test_roi_dialog_fit_timer_runs_immediately_with_patch(app) -> None:
+    img = np.zeros((30, 30), dtype=np.uint8)
+    with patch("PySide6.QtCore.QTimer.singleShot", lambda _ms, fn: fn()):
+        dlg = ROISelectionDialog(img)
+        dlg.close()
+
+
+def test_roi_dialog_middle_button_pan(app) -> None:
+    img = np.zeros((40, 40), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    v = dlg._view
+
+    class _E:
+        def __init__(self, typ, pos_f: QPointF, btn: Qt.MouseButton, buttons: Qt.MouseButton) -> None:
+            self._typ = typ
+            self._pos = pos_f
+            self._btn = btn
+            self._buttons = buttons
+
+        def accept(self) -> None:
+            pass
+
+        def button(self) -> Qt.MouseButton:
+            return self._btn
+
+        def buttons(self) -> Qt.MouseButton:
+            return self._buttons
+
+        def position(self) -> QPointF:
+            return self._pos
+
+    v.mousePressEvent(_E("press", QPointF(10, 10), Qt.MouseButton.MiddleButton, Qt.MouseButton.MiddleButton))
+    v.mouseMoveEvent(_E("move", QPointF(20, 15), Qt.MouseButton.NoButton, Qt.MouseButton.MiddleButton))
+    v.mouseReleaseEvent(_E("rel", QPointF(20, 15), Qt.MouseButton.MiddleButton, Qt.MouseButton.NoButton))
+    dlg.close()
+
+
+def test_roi_dialog_preview_line_on_mouse_move_while_drawing(app) -> None:
+    img = np.zeros((60, 60), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(5, 5))
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(30, 5))
+    dlg._handle_mouse_move(_empty_event(), QPointF(40, 40))
+    assert dlg._preview_pos is not None
+    dlg.close()
+
+
+def test_roi_dialog_double_click_finishes_polygon(app) -> None:
+    img = np.zeros((80, 80), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    for xy in ((10.0, 10.0), (70.0, 10.0), (40.0, 70.0)):
+        dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(*xy))
+    dlg._handle_mouse_double_click(_mb_event(Qt.MouseButton.LeftButton), QPointF(40.0, 40.0))
+    assert dlg._current_roi is not None
+    dlg.close()
+
+
+def test_roi_dialog_complete_polygon_near_closing_point_drops_last(app) -> None:
+    img = np.zeros((100, 100), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._polygon_points = [QPointF(10, 10), QPointF(80, 10), QPointF(80, 80), QPointF(12, 12)]
+    dlg._complete_polygon()
+    assert dlg._current_roi is not None
+    assert len(dlg._current_roi.points or []) == 3
+    dlg.close()
+
+
+def test_roi_dialog_complete_polygon_ignored_with_few_points(app) -> None:
+    img = np.zeros((40, 40), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._polygon_points = [QPointF(1, 1), QPointF(2, 2)]
+    dlg._complete_polygon()
+    assert dlg._current_roi is None
+    dlg.close()
+
+
+def test_roi_dialog_backspace_removes_last_vertex(app) -> None:
+    img = np.zeros((50, 50), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(5, 5))
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(40, 40))
+    ev = QKeyEvent(QKeyEvent.Type.KeyPress, int(Qt.Key.Key_Backspace), Qt.KeyboardModifier.NoModifier)
+    dlg._handle_key_press(ev)
+    assert len(dlg._polygon_points) == 1
+    dlg.close()
+
+
+def test_roi_dialog_get_roi(app) -> None:
+    img = np.zeros((20, 20), dtype=np.uint8)
+    pts = [(2, 2), (18, 2), (18, 18), (2, 18)]
+    roi = ROI.from_dict({"shape": "polygon", "points": pts})
+    dlg = ROISelectionDialog(img, existing_roi=roi)
+    assert dlg.get_roi() is roi
+    dlg.close()
+
+
+def test_roi_dialog_adjust_mode_drag_vertex(app) -> None:
+    img = np.zeros((100, 100), dtype=np.uint8)
+    pts = [(20, 20), (80, 20), (80, 80), (20, 80)]
+    roi = ROI.from_dict({"shape": "polygon", "points": pts})
+    dlg = ROISelectionDialog(img, existing_roi=roi)
+    dlg._on_fit_view()
+    dlg._adjust_mode = True
+    dlg._update_overlay()
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(20, 20))
+    assert dlg._dragging_handle != ROIHandle.NONE
+    dlg._handle_mouse_move(_empty_event(), QPointF(25, 25))
+    dlg._handle_mouse_release(_mb_event(Qt.MouseButton.LeftButton), QPointF(25, 25))
+    dlg.close()
+
+
+def test_roi_dialog_right_click_deletes_vertex_in_adjust_mode(app) -> None:
+    img = np.zeros((100, 100), dtype=np.uint8)
+    pts = [(20, 20), (80, 20), (80, 80), (20, 80)]
+    roi = ROI.from_dict({"shape": "polygon", "points": pts})
+    dlg = ROISelectionDialog(img, existing_roi=roi)
+    dlg._on_fit_view()
+    dlg._adjust_mode = True
+    dlg._update_overlay()
+    dlg._handle_mouse_press(_mb_event(Qt.MouseButton.RightButton), QPointF(20, 20))
+    assert dlg._current_roi is not None
+    assert len(dlg._current_roi.points or []) == 3
+    dlg.close()
+
+
+def test_roi_dialog_double_click_drops_duplicate_last_point(app) -> None:
+    img = np.zeros((60, 60), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    dlg._polygon_points = [QPointF(5, 5), QPointF(55, 5), QPointF(55, 55), QPointF(55, 55)]
+    dlg._handle_mouse_double_click(_mb_event(Qt.MouseButton.LeftButton), QPointF(30, 30))
+    assert dlg._current_roi is not None
+    dlg.close()
+
+
+def test_roi_dialog_zoom_hits_min_max_bounds(app) -> None:
+    img = np.zeros((30, 30), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    for _ in range(40):
+        dlg._view.zoom_in()
+    for _ in range(40):
+        dlg._view.zoom_out()
+    dlg.close()
+
+
+def test_roi_dialog_view_routes_double_click_to_dialog(app) -> None:
+    img = np.zeros((60, 60), dtype=np.uint8)
+    dlg = ROISelectionDialog(img)
+    dlg._on_fit_view()
+    for xy in ((5.0, 5.0), (55.0, 5.0), (30.0, 55.0)):
+        dlg._handle_mouse_press(_mb_event(Qt.MouseButton.LeftButton), QPointF(*xy))
+
+    class _DE:
+        def accept(self) -> None:
+            pass
+
+        def button(self) -> Qt.MouseButton:
+            return Qt.MouseButton.LeftButton
+
+        def position(self) -> QPointF:
+            return QPointF(30, 30)
+
+    dlg._view.mouseDoubleClickEvent(_DE())
+    assert dlg._current_roi is not None
+    dlg.close()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -7,7 +7,8 @@ matplotlib.use("Agg")
 from unittest.mock import patch
 
 import pytest
-from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication, QColorDialog
 
 from ui.settings_dialog import ROI_LABELS, THEME_VALUES, SettingsDialog
 
@@ -165,3 +166,34 @@ class TestSettingsDialogApply:
                                 dialog._apply_and_accept()
                                 mock_peak.assert_called_once_with("#112233")
                                 mock_trough.assert_called_once_with("#445566")
+
+
+class TestSettingsDialogColorPickers:
+    """Cover QColorDialog branches that update swatches and stored hex values."""
+
+    def test_pick_roi_color_applies_valid_choice(self, app):
+        with patch.object(QColorDialog, "getColor", return_value=QColor("#abcdef")):
+            d = SettingsDialog()
+            d._pick_roi_color("roi_1")
+            assert d._roi_colors["roi_1"] == "#abcdef"
+
+    def test_pick_avg_traj_color_applies_valid_choice(self, app):
+        with patch.object(QColorDialog, "getColor", return_value=QColor("#112233")):
+            d = SettingsDialog()
+            d._pick_avg_traj_color()
+            assert d._avg_traj_color == "#112233"
+
+    def test_pick_avg_roi_color_applies_valid_choice(self, app):
+        with patch.object(QColorDialog, "getColor", return_value=QColor("#445566")):
+            d = SettingsDialog()
+            d._pick_avg_roi_color("roi_1")
+            assert d._avg_traj_roi_colors["roi_1"] == "#445566"
+
+    def test_pick_peak_and_trough_colors_apply(self, app):
+        with patch.object(QColorDialog, "getColor", return_value=QColor("#778899")):
+            d = SettingsDialog()
+            d._pick_peak_color()
+            assert d._peak_marker_color == "#778899"
+        with patch.object(QColorDialog, "getColor", return_value=QColor("#aabbcc")):
+            d._pick_trough_color()
+            assert d._trough_marker_color == "#aabbcc"

--- a/tests/test_startup_dialog.py
+++ b/tests/test_startup_dialog.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
 from PySide6.QtCore import QPoint, Qt
 from PySide6.QtWidgets import QApplication, QDialog, QMessageBox
 
-from ui.startup_dialog import NewExperimentDialog, RecentExperimentRow, StartupDialog
+from ui.startup_dialog import NewExperimentDialog, RecentExperimentRow, StartupDialog, _public_recent_row_label
 
 
 @pytest.fixture
@@ -28,6 +28,34 @@ def experiments_dir(tmp_path):
 
 
 # ── RecentExperimentRow ──────────────────────────────────────────────────
+
+
+class TestPublicRecentRowLabel:
+    def test_uses_owner_field(self) -> None:
+        assert _public_recent_row_label({"name": "My Study", "owner": "alice"}, "/x/y.nexp") == "My Study - by alice"
+
+    def test_owner_field_preserves_exact_casing(self) -> None:
+        assert (
+            _public_recent_row_label({"name": "My Study", "owner": "SoMeUsEr"}, "/x/y.nexp") == "My Study - by SoMeUsEr"
+        )
+
+    def test_parses_owner_from_public_copy_filename(self) -> None:
+        assert (
+            _public_recent_row_label({"name": "My Study"}, r"C:\users\Public\experiments\bob__MyStudy.nexp")
+            == "My Study - by bob"
+        )
+
+    def test_parses_owner_casing_from_filename(self) -> None:
+        assert (
+            _public_recent_row_label(
+                {"name": "My Study"},
+                r"C:\users\Public\experiments\MiXeD__MyStudy.nexp",
+            )
+            == "My Study - by MiXeD"
+        )
+
+    def test_fallback_without_owner(self) -> None:
+        assert _public_recent_row_label({"name": "Solo"}, "/no/underscore.nexp") == "Solo"
 
 
 class TestRecentExperimentRow:
@@ -71,7 +99,7 @@ class TestNewExperimentDialog:
         assert dlg.isModal() is True
 
     def test_default_date_is_today(self, app, experiments_dir) -> None:
-        expected = datetime.utcnow().strftime("%Y-%m-%d")
+        expected = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         dlg = NewExperimentDialog(experiments_dir)
         assert expected in dlg.date_edit.text()
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,53 @@
+"""Tests for theme palettes and stylesheet helpers (``ui.styles``)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from ui.styles import (
+    THEME_DARK,
+    THEME_DARK_HIGH_CONTRAST,
+    THEME_LIGHT,
+    THEME_LIGHT_HIGH_CONTRAST,
+    _palette,
+    get_mpl_theme,
+    get_stylesheet,
+)
+
+
+@pytest.mark.parametrize(
+    "theme",
+    [
+        THEME_DARK,
+        THEME_LIGHT,
+        THEME_DARK_HIGH_CONTRAST,
+        THEME_LIGHT_HIGH_CONTRAST,
+    ],
+)
+def test_palette_and_stylesheet_for_all_themes(theme: str) -> None:
+    pal = _palette(theme)
+    assert "bg" in pal and "text" in pal
+    ss = get_stylesheet(theme)
+    assert len(ss) > 500
+
+
+def test_palette_unknown_falls_back_to_dark() -> None:
+    pal = _palette("not-a-real-theme")
+    assert pal == _palette(THEME_DARK)
+
+
+@patch("ui.app_settings.get_roi_colors", return_value={"roi_1": "#111", "roi_2": "#222"})
+@patch("ui.app_settings.get_avg_trajectory_color", return_value="#333")
+@patch("ui.app_settings.get_avg_trajectory_roi_colors", return_value={"roi_1": "#444", "roi_2": "#555"})
+@patch("ui.app_settings.get_peak_marker_color", return_value="#666")
+@patch("ui.app_settings.get_trough_marker_color", return_value="#777")
+def test_get_mpl_theme_dark_and_light_branches(
+    *_mocks,
+) -> None:
+    dark = get_mpl_theme(THEME_DARK)
+    light = get_mpl_theme(THEME_LIGHT)
+    assert dark["good_color"] != light["good_color"]
+    hc = get_mpl_theme(THEME_DARK_HIGH_CONTRAST)
+    assert "neutral_color" in hc

--- a/tests/test_user_selection.py
+++ b/tests/test_user_selection.py
@@ -17,7 +17,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from PySide6.QtCore import QEvent, QPointF, Qt
-from PySide6.QtGui import QEnterEvent, QFocusEvent, QKeyEvent, QMouseEvent
+from PySide6.QtGui import QEnterEvent, QFocusEvent, QKeyEvent
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QDialog, QGridLayout, QMessageBox, QWidget
 
 from core.experiment_manager import Experiment  # pyright: ignore[reportMissingImports]
@@ -671,14 +672,12 @@ def test_user_card_mouse_click_emits_login_requested(app):
     card = _UserCard("Alice", grid_row=0, grid_col=0, grid_cols=1, parent=parent)
     called = []
     card.login_requested.connect(lambda user: called.append(user))
-    event = QMouseEvent(
-        QMouseEvent.Type.MouseButtonPress,
+    QTest.mouseClick(
+        card,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
         card.rect().center(),
-        Qt.LeftButton,
-        Qt.LeftButton,
-        Qt.NoModifier,
     )
-    card.mousePressEvent(event)
     assert called == ["Alice"]
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -316,3 +316,62 @@ def test_stepper_description_shows_current_step(app) -> None:
     stepper = WorkflowStepper(wm)
     desc_text = stepper._description_label.text()
     assert len(desc_text) > 0
+
+
+def _advance_workflow_to(wm: WorkflowManager, target: WorkflowStep) -> None:
+    while wm.current_step != target:
+        wm.mark_step_ready(wm.current_step)
+        assert wm.complete_current_step() is True
+
+
+def test_stepper_set_read_only_installs_and_removes_guards(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    stepper = WorkflowStepper(wm)
+    stepper.set_read_only(True)
+    assert stepper._read_only_enabled is True
+    assert len(stepper._read_only_guards) > 0
+    stepper.set_read_only(False)
+    assert stepper._read_only_enabled is False
+    assert stepper._read_only_guards == []
+
+
+def test_stepper_set_read_only_idempotent(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    stepper = WorkflowStepper(wm)
+    stepper.set_read_only(True)
+    n = len(stepper._read_only_guards)
+    stepper.set_read_only(True)
+    assert len(stepper._read_only_guards) == n
+
+
+def test_stepper_skip_alignment_advances_from_align_step(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    stepper = WorkflowStepper(wm)
+    _advance_workflow_to(wm, WorkflowStep.ALIGN_IMAGES)
+    assert wm.current_step == WorkflowStep.ALIGN_IMAGES
+    stepper._on_skip_alignment_clicked()
+    assert wm.current_step == WorkflowStep.SELECT_ROI
+
+
+def test_stepper_step_click_navigates_to_completed_step(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    wm.mark_step_ready(WorkflowStep.LOAD_IMAGES)
+    wm.complete_current_step()
+    assert wm.current_step == WorkflowStep.EDIT_IMAGES
+    stepper = WorkflowStepper(wm)
+    stepper._make_step_clicked_handler(WorkflowStep.LOAD_IMAGES)()
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+
+def test_stepper_step_click_ignored_for_locked_step(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    stepper = WorkflowStepper(wm)
+    stepper._make_step_clicked_handler(WorkflowStep.ANALYZE_GRAPHS)()
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES
+
+
+def test_stepper_step_click_noop_when_already_current(app) -> None:
+    wm = WorkflowManager(_fresh_experiment())
+    stepper = WorkflowStepper(wm)
+    stepper._make_step_clicked_handler(WorkflowStep.LOAD_IMAGES)()
+    assert wm.current_step == WorkflowStep.LOAD_IMAGES


### PR DESCRIPTION
Implements the Public User feature. The Public User only has access to experiments that are labeled as public by normal users and the Public User only has read access to given experiments so it can not edit experiment data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public User profile with a Public-mode toggle and automatic synchronization of experiments marked public
  * Per-experiment public visibility flag so experiments can be shown in the Public profile

* **Behavior Changes**
  * Public User mode enforces read-only restrictions across the UI and prevents saving/altering public experiments

* **Tests / Assets**
  * Much-expanded test coverage across core and UI components; added GETTING_STARTED/TEST_IMAGES.zip for tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->